### PR TITLE
feat(conntrack): make map max entries configurable

### DIFF
--- a/deploy/standard/manifests/controller/helm/retina/templates/configmap.yaml
+++ b/deploy/standard/manifests/controller/helm/retina/templates/configmap.yaml
@@ -30,6 +30,7 @@ data:
     packetParserRingBuffer: {{ .Values.packetParserRingBuffer }}
     packetParserRingBufferSize: {{ .Values.packetParserRingBufferSize }}
     filterMapMaxEntries: {{ .Values.filterMapMaxEntries }}
+    conntrackMaxEntries: {{ .Values.conntrackMaxEntries }}
 {{- end}}
 ---
 {{- if .Values.os.windows}}

--- a/deploy/standard/manifests/controller/helm/retina/values.yaml
+++ b/deploy/standard/manifests/controller/helm/retina/values.yaml
@@ -72,6 +72,7 @@ packetParserRingBufferSize: 8388608
 # This map tracks IP addresses of pods of interest for network observability.
 # Default: 255. Increase for large clusters with many tracked pods.
 filterMapMaxEntries: 255
+conntrackMaxEntries: 262144
 
 imagePullSecrets: []
 nameOverride: "retina"

--- a/docs/02-Installation/03-Config.md
+++ b/docs/02-Installation/03-Config.md
@@ -56,6 +56,7 @@ Apply to both Agent and Operator.
 * `dataSamplingRate`: Defines the data sampling rate for `packetparser`.  See [Sampling](../03-Metrics/plugins/Linux/packetparser.md#sampling) for more details.
 * `packetParserRingBuffer`: Selects the kernel-to-userspace transport for `packetparser`. Accepted values: `enabled` (ring buffer) or `disabled` (perf event array). `auto` is reserved for future use.
 * `packetParserRingBufferSize`: Ring buffer size in bytes when `packetParserRingBuffer=enabled`. Must be a power of two between the kernel page size and 1GiB (inclusive); invalid values cause startup to fail.
+* `conntrackMaxEntries`: Maximum number of entries in the conntrack map (default `262144`). Raise it for clusters tracking many concurrent connections to avoid premature LRU eviction. Applied to the pinned map at init; changing it takes effect on init-container restart.
 
 ## Operator Configuration
 

--- a/init/retina/main_linux.go
+++ b/init/retina/main_linux.go
@@ -60,7 +60,7 @@ func run(args ...string) error {
 	}
 
 	// Setup BPF
-	err = bpf.Setup(l, cfg.FilterMapMaxEntries)
+	err = bpf.Setup(l, cfg.FilterMapMaxEntries, cfg.ConntrackMaxEntries)
 	if err != nil {
 		return errors.Wrap(err, "failed to setup Retina bpf filesystem")
 	}

--- a/pkg/bpf/setup_linux.go
+++ b/pkg/bpf/setup_linux.go
@@ -55,7 +55,7 @@ func mountBpfFs() error {
 	return nil
 }
 
-func Setup(l *zap.Logger, filterMapMaxEntries uint32) error {
+func Setup(l *zap.Logger, filterMapMaxEntries, conntrackMaxEntries uint32) error {
 	err := mountBpfFs()
 	if err != nil {
 		return errors.Wrap(err, "failed to mount BPF filesystem")
@@ -85,7 +85,7 @@ func Setup(l *zap.Logger, filterMapMaxEntries uint32) error {
 	l.Info("Deleted existing conntrack map file", zap.String("path", plugincommon.MapPath), zap.String("Map name", plugincommon.ConntrackMapName))
 	// Initialize the conntrack map.
 	// This will create the conntrack map in kernel and pin it to /sys/fs/bpf.
-	err = conntrack.Init()
+	err = conntrack.Init(conntrackMaxEntries)
 	if err != nil {
 		return errors.Wrap(err, "failed to initialize conntrack map")
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -59,6 +59,7 @@ var (
 	DefaultTelemetryInterval          = 15 * time.Minute
 	DefaultSamplingRate        uint32 = 1
 	DefaultFilterMapMaxEntries uint32 = 255
+	DefaultConntrackMaxEntries uint32 = 262144
 )
 
 func (l *Level) UnmarshalText(text []byte) error {
@@ -134,6 +135,7 @@ type Config struct {
 	PacketParserRingBuffer     PacketParserRingBufferMode `yaml:"packetParserRingBuffer"`
 	PacketParserRingBufferSize uint32                     `yaml:"packetParserRingBufferSize"`
 	FilterMapMaxEntries        uint32                     `yaml:"filterMapMaxEntries"`
+	ConntrackMaxEntries        uint32                     `yaml:"conntrackMaxEntries"`
 	EnableTCX                  TCXMode                    `yaml:"enableTCX"`
 }
 
@@ -192,6 +194,11 @@ func GetConfig(cfgFilename string) (*Config, error) {
 	// Default filter map max entries to 255 if not set.
 	if config.FilterMapMaxEntries == 0 {
 		config.FilterMapMaxEntries = DefaultFilterMapMaxEntries
+	}
+
+	// Default conntrack max entries if not set.
+	if config.ConntrackMaxEntries == 0 {
+		config.ConntrackMaxEntries = DefaultConntrackMaxEntries
 	}
 
 	// Default EnableTCX to "auto" if unset, reject unknown values.

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -52,6 +52,12 @@ func TestGetConfig_DefaultTelemetryInterval(t *testing.T) {
 	}
 }
 
+func TestGetConfig_DefaultConntrackMaxEntries(t *testing.T) {
+	c, err := GetConfig("./testwith/config.yaml")
+	require.NoError(t, err)
+	require.Equal(t, DefaultConntrackMaxEntries, c.ConntrackMaxEntries)
+}
+
 func TestDecodeLevelHook(t *testing.T) {
 	tests := []struct {
 		input    interface{}

--- a/pkg/managers/pluginmanager/pluginmanager.go
+++ b/pkg/managers/pluginmanager/pluginmanager.go
@@ -144,7 +144,7 @@ func (p *PluginManager) Start(ctx context.Context) error {
 	_, isPacketParserEnabled := p.plugins[pluginNamePacketparser]
 	// run conntrack GC only if packetparser is enabled
 	if isPacketParserEnabled {
-		ct, connErr := conntrack.New()
+		ct, connErr := conntrack.New(p.cfg.ConntrackMaxEntries)
 		if connErr != nil {
 			return errors.Wrap(connErr, "failed to get conntrack instance")
 		}

--- a/pkg/plugin/conntrack/conntrack_linux.go
+++ b/pkg/plugin/conntrack/conntrack_linux.go
@@ -31,37 +31,59 @@ var conntrackMetricsEnabled = false // conntrack metrics global variable
 // Init initializes the conntrack eBPF map in the kernel for the first time.
 // This function should be called in the init container since
 // it requires securityContext.privileged to be true.
-func Init() error {
+func Init(maxEntries uint32) error {
 	// Allow the current process to lock memory for eBPF resources.
 	if err := rlimit.RemoveMemlock(); err != nil {
 		return errors.Wrapf(err, "failed to remove memlock limit")
 	}
 
 	objs := &conntrackObjects{}
-	err := loadConntrackObjects(objs, &ebpf.CollectionOptions{
+	err := loadConntrackObjectsWithMaxEntries(objs, &ebpf.CollectionOptions{
 		Maps: ebpf.MapOptions{
 			PinPath: plugincommon.MapPath,
 		},
-	})
+	}, maxEntries)
 	if err != nil {
 		return errors.Wrap(err, "failed to load conntrack objects")
 	}
 	return nil
 }
 
+// loadConntrackObjectsWithMaxEntries loads the conntrack objects, overriding the
+// conntrack map's max entries when a non-zero value is provided.
+func loadConntrackObjectsWithMaxEntries(objs *conntrackObjects, opts *ebpf.CollectionOptions, maxEntries uint32) error {
+	spec, err := loadConntrack()
+	if err != nil {
+		return err
+	}
+	setConntrackMapMaxEntries(spec, maxEntries)
+	return spec.LoadAndAssign(objs, opts)
+}
+
+// setConntrackMapMaxEntries overrides the conntrack map's max entries when a
+// non-zero value is provided.
+func setConntrackMapMaxEntries(spec *ebpf.CollectionSpec, maxEntries uint32) {
+	if maxEntries == 0 {
+		return
+	}
+	if ms, ok := spec.Maps[plugincommon.ConntrackMapName]; ok {
+		ms.MaxEntries = maxEntries
+	}
+}
+
 // New returns a new Conntrack instance.
-func New() (*Conntrack, error) {
+func New(maxEntries uint32) (*Conntrack, error) {
 	ct := &Conntrack{
 		l:           log.Logger().Named("conntrack"),
 		gcFrequency: defaultGCFrequency,
 	}
 
 	objs := &conntrackObjects{}
-	err := loadConntrackObjects(objs, &ebpf.CollectionOptions{
+	err := loadConntrackObjectsWithMaxEntries(objs, &ebpf.CollectionOptions{
 		Maps: ebpf.MapOptions{
 			PinPath: plugincommon.MapPath,
 		},
-	})
+	}, maxEntries)
 	if err != nil {
 		ct.l.Error("loadConntrackObjects failed", zap.Error(err))
 		return nil, errors.Wrap(err, "failed to load conntrack objects")

--- a/pkg/plugin/conntrack/conntrack_linux_test.go
+++ b/pkg/plugin/conntrack/conntrack_linux_test.go
@@ -7,6 +7,8 @@ import (
 	"path"
 	"runtime"
 	"testing"
+
+	plugincommon "github.com/microsoft/retina/pkg/plugin/common"
 )
 
 func TestBuildDynamicHeaderPath(t *testing.T) {
@@ -89,4 +91,29 @@ func getCurrentFilePath(t *testing.T) string {
 		t.Fatal("failed to determine test file path")
 	}
 	return filename
+}
+
+func TestSetConntrackMapMaxEntries(t *testing.T) {
+	spec, err := loadConntrack()
+	if err != nil {
+		t.Fatalf("failed to load conntrack spec: %v", err)
+	}
+	ms, ok := spec.Maps[plugincommon.ConntrackMapName]
+	if !ok {
+		t.Fatalf("conntrack map %q not found in spec", plugincommon.ConntrackMapName)
+	}
+	original := ms.MaxEntries
+
+	// Zero leaves the compiled default unchanged.
+	setConntrackMapMaxEntries(spec, 0)
+	if ms.MaxEntries != original {
+		t.Errorf("expected max entries unchanged at %d, got %d", original, ms.MaxEntries)
+	}
+
+	// Non-zero overrides the map size.
+	const want uint32 = 500000
+	setConntrackMapMaxEntries(spec, want)
+	if ms.MaxEntries != want {
+		t.Errorf("expected max entries %d, got %d", want, ms.MaxEntries)
+	}
 }

--- a/pkg/plugin/conntrack/conntrack_windows.go
+++ b/pkg/plugin/conntrack/conntrack_windows.go
@@ -7,7 +7,7 @@ import (
 type Conntrack struct{}
 
 // Not implemented for Windows
-func New() (*Conntrack, error) {
+func New(_ uint32) (*Conntrack, error) {
 	return &Conntrack{}, nil
 }
 

--- a/pkg/plugin/packetparser/packetparser_linux.go
+++ b/pkg/plugin/packetparser/packetparser_linux.go
@@ -257,6 +257,11 @@ func (p *packetParser) Init() error {
 		mapSpec.MaxEntries = p.cfg.FilterMapMaxEntries
 	}
 
+	// Override conntrack map max entries to match the configured size from init container.
+	if mapSpec, ok := spec.Maps[plugincommon.ConntrackMapName]; ok && p.cfg.ConntrackMaxEntries > 0 {
+		mapSpec.MaxEntries = p.cfg.ConntrackMaxEntries
+	}
+
 	//nolint:typecheck
 	if err := spec.LoadAndAssign(objs, &ebpf.CollectionOptions{ //nolint:typecheck
 		Maps: ebpf.MapOptions{


### PR DESCRIPTION
# Description

Allows configuring the conntrack map maximum size, e.g. for systems tracking lots of connections.

## Checklist

- [X] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [X] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [X] I have correctly attributed the author(s) of the code.
- [X] I have tested the changes locally.
- [X] I have followed the project's style guidelines.
- [X] I have updated the documentation, if necessary.
- [X] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

Unit tests added, deployed with a custom size on a test cluster.

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
