### PR TITLE
feat(endpoint): event-driven veth attach with snapshot-on-subscribe

### DIFF
--- a/.github/workflows/test-ebpf.yaml
+++ b/.github/workflows/test-ebpf.yaml
@@ -6,12 +6,14 @@ on:
       - 'pkg/plugin/**/_cprog/**'
       - 'pkg/plugin/**/*_ebpf_test.go'
       - 'pkg/plugin/ebpftest/**'
+      - 'pkg/watchers/**'
   pull_request:
     branches: [main]
     paths:
       - 'pkg/plugin/**/_cprog/**'
       - 'pkg/plugin/**/*_ebpf_test.go'
       - 'pkg/plugin/ebpftest/**'
+      - 'pkg/watchers/**'
   workflow_dispatch:
 
 permissions:
@@ -46,4 +48,4 @@ jobs:
 
       - name: Run eBPF program tests
         run: |
-          sudo $(which go) test -tags=ebpf -v -count=1 ./pkg/plugin/...
+          sudo $(which go) test -tags=ebpf -v -count=1 ./pkg/plugin/... ./pkg/watchers/...

--- a/Makefile
+++ b/Makefile
@@ -466,8 +466,8 @@ test: # Run unit tests.
 	bash -o pipefail -c 'KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use -p path)" go test -tags=unit,dashboard -skip=TestE2E* -coverprofile=coverage.out -v -json ./... | ./test-summary --progress --verbose'
 
 .PHONY: test-ebpf
-test-ebpf: # Run eBPF program tests (requires root/CAP_BPF).
-	sudo $$(which go) test -tags=ebpf -v -count=1 ./pkg/plugin/...
+test-ebpf: # Run eBPF program tests (requires root/CAP_BPF; watcher tests need NET_ADMIN).
+	sudo $$(which go) test -tags=ebpf -v -count=1 ./pkg/plugin/... ./pkg/watchers/...
 
 coverage: # Code coverage.
 #	go generate ./... && go test -tags=unit -coverprofile=coverage.out.tmp ./...

--- a/cmd/standard/daemon.go
+++ b/cmd/standard/daemon.go
@@ -245,6 +245,9 @@ func (d *Daemon) Start() error {
 	if daemonConfig.EnablePodLevel {
 		pubSub := pubsub.New()
 		controllerCache := controllercache.New(pubSub)
+		// This is the cache the k8s controllers below feed; serve pod/svc/node
+		// snapshots to late pubsub subscribers from it.
+		controllerCache.RegisterSnapshotSources()
 		enrich := enricher.New(ctx, controllerCache)
 		//nolint:govet // shadowing this err is fine
 		fm, err := filtermanager.Init(5, daemonConfig.FilterMapMaxEntries) //nolint:gomnd // defaults

--- a/deploy/hubble/manifests/controller/helm/retina/templates/agent/configmap.yaml
+++ b/deploy/hubble/manifests/controller/helm/retina/templates/agent/configmap.yaml
@@ -116,6 +116,8 @@ data:
     monitorSockPath: {{ .Values.monitorSockPath }}
     packetParserRingBuffer: {{ .Values.packetParserRingBuffer }}
     packetParserRingBufferSize: {{ .Values.packetParserRingBufferSize }}
+    enableEndpointNetlinkEvents: {{ .Values.enableEndpointNetlinkEvents }}
+    watcherRefreshInterval: {{ .Values.watcherRefreshInterval }}
 {{- end}}
 ---
 {{- if .Values.os.windows}}

--- a/deploy/hubble/manifests/controller/helm/retina/values.yaml
+++ b/deploy/hubble/manifests/controller/helm/retina/values.yaml
@@ -83,6 +83,10 @@ packetParserRingBuffer: "disabled"
 # Invalid values cause startup to fail with a validation error.
 # This value is not applied when ring buffers are disabled.
 packetParserRingBufferSize: 8388608
+# Attach eBPF programs on veth netlink events instead of waiting for the watcher refresh.
+enableEndpointNetlinkEvents: false
+# Watcher re-list interval.
+watcherRefreshInterval: "30s"
 
 imagePullSecrets: []
 nameOverride: "retina"

--- a/deploy/standard/manifests/controller/helm/retina/templates/configmap.yaml
+++ b/deploy/standard/manifests/controller/helm/retina/templates/configmap.yaml
@@ -30,6 +30,8 @@ data:
     packetParserRingBuffer: {{ .Values.packetParserRingBuffer }}
     packetParserRingBufferSize: {{ .Values.packetParserRingBufferSize }}
     filterMapMaxEntries: {{ .Values.filterMapMaxEntries }}
+    enableEndpointNetlinkEvents: {{ .Values.enableEndpointNetlinkEvents }}
+    watcherRefreshInterval: {{ .Values.watcherRefreshInterval }}
 {{- end}}
 ---
 {{- if .Values.os.windows}}

--- a/deploy/standard/manifests/controller/helm/retina/values.yaml
+++ b/deploy/standard/manifests/controller/helm/retina/values.yaml
@@ -72,6 +72,10 @@ packetParserRingBufferSize: 8388608
 # This map tracks IP addresses of pods of interest for network observability.
 # Default: 255. Increase for large clusters with many tracked pods.
 filterMapMaxEntries: 255
+# Attach eBPF programs on veth netlink events instead of waiting for the watcher refresh.
+enableEndpointNetlinkEvents: false
+# Watcher re-list interval.
+watcherRefreshInterval: "30s"
 
 imagePullSecrets: []
 nameOverride: "retina"

--- a/docs/02-Installation/03-Config.md
+++ b/docs/02-Installation/03-Config.md
@@ -56,6 +56,8 @@ Apply to both Agent and Operator.
 * `dataSamplingRate`: Defines the data sampling rate for `packetparser`.  See [Sampling](../03-Metrics/plugins/Linux/packetparser.md#sampling) for more details.
 * `packetParserRingBuffer`: Selects the kernel-to-userspace transport for `packetparser`. Accepted values: `enabled` (ring buffer) or `disabled` (perf event array). `auto` is reserved for future use.
 * `packetParserRingBufferSize`: Ring buffer size in bytes when `packetParserRingBuffer=enabled`. Must be a power of two between the kernel page size and 1GiB (inclusive); invalid values cause startup to fail.
+* `enableEndpointNetlinkEvents`: If true, the endpoint watcher subscribes to netlink link events and reconciles immediately when a veth appears or disappears, so eBPF programs attach within milliseconds of pod creation instead of waiting for the next periodic refresh. Default `false`. Linux only; the periodic refresh remains as a backstop.
+* `watcherRefreshInterval`: Interval (in `time.Duration`, default `30s`) at which the endpoint and API server watchers re-list and reconcile state. With `enableEndpointNetlinkEvents` this acts as a self-healing backstop rather than the primary attach path.
 
 ## Operator Configuration
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -119,22 +119,24 @@ type Config struct {
 	EnabledPlugin   []string      `yaml:"enabledPlugin"`
 	MetricsInterval time.Duration `yaml:"metricsInterval"`
 	// Deprecated: Use only MetricsInterval instead in the go code.
-	MetricsIntervalDuration    time.Duration              `yaml:"metricsIntervalDuration"`
-	EnableTelemetry            bool                       `yaml:"enableTelemetry"`
-	EnableRetinaEndpoint       bool                       `yaml:"enableRetinaEndpoint"`
-	EnablePodLevel             bool                       `yaml:"enablePodLevel"`
-	EnableConntrackMetrics     bool                       `yaml:"enableConntrackMetrics"`
-	RemoteContext              bool                       `yaml:"remoteContext"`
-	EnableAnnotations          bool                       `yaml:"enableAnnotations"`
-	BypassLookupIPOfInterest   bool                       `yaml:"bypassLookupIPOfInterest"`
-	DataAggregationLevel       Level                      `yaml:"dataAggregationLevel"`
-	MonitorSockPath            string                     `yaml:"monitorSockPath"`
-	TelemetryInterval          time.Duration              `yaml:"telemetryInterval"`
-	DataSamplingRate           uint32                     `yaml:"dataSamplingRate"`
-	PacketParserRingBuffer     PacketParserRingBufferMode `yaml:"packetParserRingBuffer"`
-	PacketParserRingBufferSize uint32                     `yaml:"packetParserRingBufferSize"`
-	FilterMapMaxEntries        uint32                     `yaml:"filterMapMaxEntries"`
-	EnableTCX                  TCXMode                    `yaml:"enableTCX"`
+	MetricsIntervalDuration     time.Duration              `yaml:"metricsIntervalDuration"`
+	EnableTelemetry             bool                       `yaml:"enableTelemetry"`
+	EnableRetinaEndpoint        bool                       `yaml:"enableRetinaEndpoint"`
+	EnablePodLevel              bool                       `yaml:"enablePodLevel"`
+	EnableConntrackMetrics      bool                       `yaml:"enableConntrackMetrics"`
+	RemoteContext               bool                       `yaml:"remoteContext"`
+	EnableAnnotations           bool                       `yaml:"enableAnnotations"`
+	BypassLookupIPOfInterest    bool                       `yaml:"bypassLookupIPOfInterest"`
+	DataAggregationLevel        Level                      `yaml:"dataAggregationLevel"`
+	MonitorSockPath             string                     `yaml:"monitorSockPath"`
+	TelemetryInterval           time.Duration              `yaml:"telemetryInterval"`
+	DataSamplingRate            uint32                     `yaml:"dataSamplingRate"`
+	PacketParserRingBuffer      PacketParserRingBufferMode `yaml:"packetParserRingBuffer"`
+	PacketParserRingBufferSize  uint32                     `yaml:"packetParserRingBufferSize"`
+	FilterMapMaxEntries         uint32                     `yaml:"filterMapMaxEntries"`
+	EnableTCX                   TCXMode                    `yaml:"enableTCX"`
+	EnableEndpointNetlinkEvents bool                       `yaml:"enableEndpointNetlinkEvents"`
+	WatcherRefreshInterval      time.Duration              `yaml:"watcherRefreshInterval"`
 }
 
 func GetConfig(cfgFilename string) (*Config, error) {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -30,7 +30,9 @@ func TestGetConfig(t *testing.T) {
 		c.TelemetryInterval != 15*time.Minute ||
 		c.DataAggregationLevel != Low ||
 		c.DataSamplingRate != 1 ||
-		c.PacketParserRingBuffer != PacketParserRingBufferDisabled {
+		c.PacketParserRingBuffer != PacketParserRingBufferDisabled ||
+		!c.EnableEndpointNetlinkEvents ||
+		c.WatcherRefreshInterval != 45*time.Second {
 		t.Errorf("Expeted config should be same as ./testwith/config.yaml; instead got %+v", c)
 	}
 }

--- a/pkg/config/testwith/config.yaml
+++ b/pkg/config/testwith/config.yaml
@@ -12,3 +12,5 @@ dataAggregationLevel: "low"
 telemetryInterval: "15m"
 packetParserRingBuffer: "disabled"
 packetParserRingBufferSize: 8388608
+enableEndpointNetlinkEvents: true
+watcherRefreshInterval: "45s"

--- a/pkg/controllers/cache/cache.go
+++ b/pkg/controllers/cache/cache.go
@@ -64,6 +64,53 @@ func New(p pubsub.PubSubInterface) *Cache {
 	return c
 }
 
+// RegisterSnapshotSources registers this cache as the pubsub snapshot provider
+// for pods, services and nodes, so a subscriber that joins after the cache is
+// populated (e.g. the metrics module, which subscribes on its first
+// MetricsConfig reconcile) replays the current state immediately. Called
+// explicitly on the cache the k8s controllers feed, NOT from New: pubsub is a
+// process singleton with one source slot per topic, so a second incidental
+// cache.New (the controller manager creates one) would otherwise silently
+// steal the slot and serve empty snapshots.
+func (c *Cache) RegisterSnapshotSources() {
+	c.pubsub.RegisterSource(common.PubSubPods, c.podSnapshot)
+	c.pubsub.RegisterSource(common.PubSubSvc, c.svcSnapshot)
+	c.pubsub.RegisterSource(common.PubSubNode, c.nodeSnapshot)
+}
+
+// podSnapshot returns the current pods as add events.
+func (c *Cache) podSnapshot() []interface{} {
+	c.RLock()
+	defer c.RUnlock()
+	events := make([]interface{}, 0, len(c.epMap))
+	for _, ep := range c.epMap {
+		events = append(events, NewCacheEvent(EventTypePodAdded, ep))
+	}
+	return events
+}
+
+// svcSnapshot returns the current services as add events.
+func (c *Cache) svcSnapshot() []interface{} {
+	c.RLock()
+	defer c.RUnlock()
+	events := make([]interface{}, 0, len(c.svcMap))
+	for _, svc := range c.svcMap {
+		events = append(events, NewCacheEvent(EventTypeSvcAdded, svc))
+	}
+	return events
+}
+
+// nodeSnapshot returns the current nodes as add events.
+func (c *Cache) nodeSnapshot() []interface{} {
+	c.RLock()
+	defer c.RUnlock()
+	events := make([]interface{}, 0, len(c.nodeMap))
+	for _, node := range c.nodeMap {
+		events = append(events, NewCacheEvent(EventTypeNodeAdded, node))
+	}
+	return events
+}
+
 // GetPodByIP returns the retina endpoint for the given IP.
 func (c *Cache) GetPodByIP(ip string) *common.RetinaEndpoint {
 	c.RLock()
@@ -448,9 +495,13 @@ func (c *Cache) publish(t EventType, obj common.PublishObj) {
 		topic = common.PubSubNode
 	}
 
-	go func() {
-		c.pubsub.Publish(topic, cev)
-	}()
+	// Publish synchronously so events for the same key keep their order: a prior
+	// dispatch-per-goroutine let an add and a later delete of the same object race
+	// and arrive reversed, leaving consumers with a stale/leaked entry. Publish
+	// only enqueues (callbacks run on subscriber goroutines), so this stays cheap
+	// under c's lock, and it cannot deadlock — Subscribe invokes snapshot sources
+	// outside the PubSub lock, so there is no PubSub-lock -> cache-lock ordering.
+	c.pubsub.Publish(topic, cev)
 }
 
 func (c *Cache) SubscribeAPIServerFn(obj interface{}) {

--- a/pkg/controllers/cache/cache_test.go
+++ b/pkg/controllers/cache/cache_test.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/microsoft/retina/pkg/common"
 	"github.com/microsoft/retina/pkg/log"
@@ -15,8 +16,94 @@ import (
 	gomock "go.uber.org/mock/gomock"
 )
 
+// TestCachePublishOrderingSameKey verifies that events for the same object are
+// delivered in the order they were produced. A prior implementation published
+// each event on its own goroutine, letting an add and a later delete of the same
+// key arrive reversed and leave consumers with a stale entry.
+func TestCachePublishOrderingSameKey(t *testing.T) {
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
+	p := pubsub.New()
+	c := New(p)
+
+	var mu sync.Mutex
+	var order []EventType
+	done := make(chan struct{}, 1)
+	cb := pubsub.CallBackFunc(func(msg interface{}) {
+		ev, ok := msg.(*CacheEvent)
+		if !ok {
+			return
+		}
+		mu.Lock()
+		order = append(order, ev.Type)
+		n := len(order)
+		mu.Unlock()
+		if n == 2 {
+			select {
+			case done <- struct{}{}:
+			default:
+			}
+		}
+	})
+	id := p.Subscribe(common.PubSubPods, &cb)
+	defer p.Unsubscribe(common.PubSubPods, id) //nolint:errcheck // best-effort cleanup in test
+
+	ep := common.NewRetinaEndpoint("pod-order", "ns1", nil)
+	ep.SetIPs(&common.IPAddresses{IPv4: net.IPv4(10, 0, 0, 9)})
+	require.NoError(t, c.UpdateRetinaEndpoint(ep))
+	require.NoError(t, c.DeleteRetinaEndpoint(ep.Key()))
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("did not receive both pod events")
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Equal(t, []EventType{EventTypePodAdded, EventTypePodDeleted}, order,
+		"add must be delivered before delete for the same key")
+}
+
+// TestCacheSnapshotReplaysCurrentPod verifies the registered pod snapshot source
+// replays the current cache state to a subscriber that joins after the pod exists.
+func TestCacheSnapshotReplaysCurrentPod(t *testing.T) {
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
+	p := pubsub.New()
+	c := New(p)
+	// Explicit, as in the daemon: New must not register sources itself, or any
+	// incidental extra cache.New on the pubsub singleton (e.g. the controller
+	// manager's) would steal the topic's snapshot slot from the real cache.
+	c.RegisterSnapshotSources()
+
+	ep := common.NewRetinaEndpoint("pod-snap", "ns1", nil)
+	ep.SetIPs(&common.IPAddresses{IPv4: net.IPv4(10, 0, 0, 20)})
+	require.NoError(t, c.UpdateRetinaEndpoint(ep))
+
+	got := make(chan string, 1)
+	cb := pubsub.CallBackFunc(func(msg interface{}) {
+		ev, ok := msg.(*CacheEvent)
+		if !ok || ev.Type != EventTypePodAdded {
+			return
+		}
+		if rep, ok := ev.Obj.(*common.RetinaEndpoint); ok {
+			select {
+			case got <- rep.Name():
+			default:
+			}
+		}
+	})
+	id := p.Subscribe(common.PubSubPods, &cb)
+	defer p.Unsubscribe(common.PubSubPods, id) //nolint:errcheck // best-effort cleanup in test
+
+	select {
+	case name := <-got:
+		assert.Equal(t, "pod-snap", name, "late subscriber should receive the current pod via snapshot")
+	case <-time.After(2 * time.Second):
+		t.Fatal("late subscriber did not receive current pod via snapshot")
+	}
+}
+
 func TestNewCache(t *testing.T) {
-	log.SetupZapLogger(log.GetDefaultLogOpts())
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	p := pubsub.NewMockPubSubInterface(ctrl)
@@ -26,7 +113,7 @@ func TestNewCache(t *testing.T) {
 }
 
 func TestCacheEndpoints(t *testing.T) {
-	log.SetupZapLogger(log.GetDefaultLogOpts())
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	p := pubsub.NewMockPubSubInterface(ctrl)
@@ -97,7 +184,7 @@ func TestCacheEndpoints(t *testing.T) {
 }
 
 func TestCacheServices(t *testing.T) {
-	log.SetupZapLogger(log.GetDefaultLogOpts())
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	p := pubsub.NewMockPubSubInterface(ctrl)
@@ -145,7 +232,7 @@ func TestCacheServices(t *testing.T) {
 }
 
 func TestCacheNodes(t *testing.T) {
-	log.SetupZapLogger(log.GetDefaultLogOpts())
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	p := pubsub.NewMockPubSubInterface(ctrl)
@@ -182,7 +269,7 @@ func TestCacheNodes(t *testing.T) {
 }
 
 func TestAddPodSvcNodeSameIP(t *testing.T) {
-	log.SetupZapLogger(log.GetDefaultLogOpts())
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	p := pubsub.NewMockPubSubInterface(ctrl)
@@ -237,7 +324,7 @@ func TestAddPodSvcNodeSameIP(t *testing.T) {
 }
 
 func TestAddPodSvcNodeSameIPDiffNS(t *testing.T) {
-	log.SetupZapLogger(log.GetDefaultLogOpts())
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	p := pubsub.NewMockPubSubInterface(ctrl)
@@ -293,7 +380,7 @@ func TestAddPodSvcNodeSameIPDiffNS(t *testing.T) {
 }
 
 func TestAddPodDiffNs(t *testing.T) {
-	log.SetupZapLogger(log.GetDefaultLogOpts())
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	p := pubsub.NewMockPubSubInterface(ctrl)
@@ -341,7 +428,7 @@ func TestAddPodDiffNs(t *testing.T) {
 }
 
 func TestFailDelete(t *testing.T) {
-	log.SetupZapLogger(log.GetDefaultLogOpts())
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	p := pubsub.NewMockPubSubInterface(ctrl)
@@ -366,7 +453,7 @@ func TestFailDelete(t *testing.T) {
 }
 
 func TestCachingNamespace(t *testing.T) {
-	log.SetupZapLogger(log.GetDefaultLogOpts())
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	p := pubsub.NewMockPubSubInterface(ctrl)

--- a/pkg/managers/pluginmanager/pluginmanager.go
+++ b/pkg/managers/pluginmanager/pluginmanager.go
@@ -57,7 +57,7 @@ func NewPluginManager(cfg *kcfg.Config, tel telemetry.Telemetry, logger *slog.Lo
 
 	if mgr.cfg.EnablePodLevel {
 		mgr.l.Info("plugin manager has pod level enabled")
-		mgr.watcherManager = watchermanager.NewWatcherManager(mgr.cfg.FilterMapMaxEntries)
+		mgr.watcherManager = watchermanager.NewWatcherManager(mgr.cfg.FilterMapMaxEntries, mgr.cfg.EnableEndpointNetlinkEvents, mgr.cfg.WatcherRefreshInterval)
 	} else {
 		mgr.l.Info("plugin manager has pod level disabled")
 	}

--- a/pkg/managers/watchermanager/watchermanager.go
+++ b/pkg/managers/watchermanager/watchermanager.go
@@ -19,14 +19,17 @@ const (
 	DefaultRefreshRate = 30 * time.Second
 )
 
-func NewWatcherManager(filterMapMaxEntries uint32) *WatcherManager {
+func NewWatcherManager(filterMapMaxEntries uint32, enableEndpointNetlinkEvents bool, refreshRate time.Duration) *WatcherManager {
+	if refreshRate <= 0 {
+		refreshRate = DefaultRefreshRate
+	}
 	return &WatcherManager{
 		Watchers: []IWatcher{
-			endpoint.Watcher(),
+			endpoint.Watcher(enableEndpointNetlinkEvents),
 			apiserver.Watcher(filterMapMaxEntries),
 		},
 		l:           log.Logger().Named("watcher-manager"),
-		refreshRate: DefaultRefreshRate,
+		refreshRate: refreshRate,
 	}
 }
 
@@ -34,9 +37,21 @@ func (wm *WatcherManager) Start(ctx context.Context) error {
 	newCtx, cancelCtx := context.WithCancel(ctx)
 	wm.cancel = cancelCtx
 
-	for _, w := range wm.Watchers {
-		if err := w.Init(ctx); err != nil {
+	for i, w := range wm.Watchers {
+		// Init with the cancellable context so any long-lived goroutines a watcher
+		// starts (e.g. the endpoint watcher's netlink subscription) are torn down
+		// by wm.cancel() on Stop, consistent with runWatcher.
+		if err := w.Init(newCtx); err != nil {
 			wm.l.Error("init failed", zap.String("watcher_type", fmt.Sprintf("%T", w)), zap.Error(err))
+			// Unwind watchers already started so a failed Start leaves nothing
+			// running even if the caller never calls Stop.
+			cancelCtx()
+			for _, started := range wm.Watchers[:i] {
+				if stopErr := started.Stop(ctx); stopErr != nil {
+					wm.l.Error("failed to stop watcher during unwind", zap.String("watcher_type", fmt.Sprintf("%T", started)), zap.Error(stopErr))
+				}
+			}
+			wm.wg.Wait()
 			return err
 		}
 		wm.wg.Add(1)
@@ -50,31 +65,41 @@ func (wm *WatcherManager) Stop(ctx context.Context) error {
 	if wm.cancel != nil {
 		wm.cancel() // cancel all runWatcher
 	}
+	// Stop every watcher and always wait for the runWatcher goroutines; an early
+	// return on the first error would leave the rest running.
+	var firstErr error
 	for _, w := range wm.Watchers {
 		if err := w.Stop(ctx); err != nil {
 			wm.l.Error("failed to stop", zap.String("watcher_type", fmt.Sprintf("%T", w)), zap.Error(err))
-			return err
+			if firstErr == nil {
+				firstErr = err
+			}
 		}
 	}
 	wm.wg.Wait() // wait for all runWatcher to stop
 	wm.l.Info("watcher manager stopped")
-	return nil
+	return firstErr
 }
 
-func (wm *WatcherManager) runWatcher(ctx context.Context, w IWatcher) error {
+func (wm *WatcherManager) runWatcher(ctx context.Context, w IWatcher) {
 	defer wm.wg.Done() // signal that this runWatcher is done
+	// Reconcile once at startup instead of waiting for the first tick. Log and
+	// continue on failure so a transient error doesn't permanently kill the watcher.
+	if err := w.Refresh(ctx); err != nil {
+		wm.l.Error("initial refresh failed", zap.Error(err), zap.String("watcher_type", fmt.Sprintf("%T", w)))
+	}
 	ticker := time.NewTicker(wm.refreshRate)
 	defer ticker.Stop()
 	for {
 		select {
 		case <-ctx.Done():
 			wm.l.Info("watcher stopping...", zap.String("watcher_type", fmt.Sprintf("%T", w)))
-			return nil
+			return
 		case <-ticker.C:
-			err := w.Refresh(ctx)
-			if err != nil {
-				wm.l.Error("refresh failed", zap.Error(err))
-				return err
+			// Log and continue so a transient failure doesn't permanently stop
+			// reconciliation; the next tick retries.
+			if err := w.Refresh(ctx); err != nil {
+				wm.l.Error("refresh failed", zap.Error(err), zap.String("watcher_type", fmt.Sprintf("%T", w)))
 			}
 		}
 	}

--- a/pkg/managers/watchermanager/watchermanager_test.go
+++ b/pkg/managers/watchermanager/watchermanager_test.go
@@ -5,7 +5,9 @@ package watchermanager
 import (
 	"context"
 	"errors"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	kcfg "github.com/microsoft/retina/pkg/config"
 	"github.com/microsoft/retina/pkg/log"
@@ -21,7 +23,7 @@ func TestStopWatcherManagerGracefully(t *testing.T) {
 	ctl := gomock.NewController(t)
 	defer ctl.Finish()
 	log.SetupZapLogger(log.GetDefaultLogOpts())
-	mgr := NewWatcherManager(kcfg.DefaultFilterMapMaxEntries)
+	mgr := NewWatcherManager(kcfg.DefaultFilterMapMaxEntries, false, 0)
 
 	mockAPIServerWatcher := mock.NewMockIWatcher(ctl)
 	mockEndpointWatcher := mock.NewMockIWatcher(ctl)
@@ -34,10 +36,14 @@ func TestStopWatcherManagerGracefully(t *testing.T) {
 	mockAPIServerWatcher.EXPECT().Init(gomock.Any()).Return(nil).AnyTimes()
 	mockEndpointWatcher.EXPECT().Init(gomock.Any()).Return(nil).AnyTimes()
 
+	mockEndpointWatcher.EXPECT().Refresh(gomock.Any()).Return(nil).AnyTimes()
+	mockAPIServerWatcher.EXPECT().Refresh(gomock.Any()).Return(nil).AnyTimes()
+
 	mockEndpointWatcher.EXPECT().Stop(gomock.Any()).Return(nil).AnyTimes()
 	mockAPIServerWatcher.EXPECT().Stop(gomock.Any()).Return(nil).AnyTimes()
 
-	ctx, _ := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	g, errctx := errgroup.WithContext(ctx)
 
 	g.Go(func() error {
@@ -57,7 +63,7 @@ func TestWatcherInitFailsGracefully(t *testing.T) {
 	mockAPIServerWatcher := mock.NewMockIWatcher(ctl)
 	mockEndpointWatcher := mock.NewMockIWatcher(ctl)
 
-	mgr := NewWatcherManager(kcfg.DefaultFilterMapMaxEntries)
+	mgr := NewWatcherManager(kcfg.DefaultFilterMapMaxEntries, false, 0)
 	mgr.Watchers = []IWatcher{
 		mockAPIServerWatcher,
 		mockEndpointWatcher,
@@ -70,12 +76,116 @@ func TestWatcherInitFailsGracefully(t *testing.T) {
 	require.NotNil(t, err, "Expected error when starting watcher manager")
 }
 
+// A failed Init partway through Start must unwind: already-started watchers are
+// stopped and their runWatcher goroutines joined, so a caller that treats the
+// error as fatal (never calling Stop) leaks nothing.
+func TestStartUnwindsOnInitFailure(t *testing.T) {
+	ctl := gomock.NewController(t)
+	defer ctl.Finish()
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
+
+	first := mock.NewMockIWatcher(ctl)
+	second := mock.NewMockIWatcher(ctl)
+
+	mgr := NewWatcherManager(kcfg.DefaultFilterMapMaxEntries, false, 0)
+	mgr.Watchers = []IWatcher{first, second}
+
+	first.EXPECT().Init(gomock.Any()).Return(nil).Times(1)
+	first.EXPECT().Refresh(gomock.Any()).Return(nil).AnyTimes()
+	// The unwind must stop the watcher that already started.
+	first.EXPECT().Stop(gomock.Any()).Return(nil).Times(1)
+	second.EXPECT().Init(gomock.Any()).Return(errInitFailed).Times(1)
+
+	err := mgr.Start(context.Background())
+	require.ErrorIs(t, err, errInitFailed)
+	// wg.Wait inside Start already joined first's runWatcher; a second Stop must
+	// also be safe (idempotent from the caller's perspective).
+	first.EXPECT().Stop(gomock.Any()).Return(nil).Times(1)
+	second.EXPECT().Stop(gomock.Any()).Return(nil).Times(1)
+	require.NoError(t, mgr.Stop(context.Background()))
+}
+
+// Stop must attempt every watcher and wait for the goroutines even when one
+// watcher's Stop fails; the first error is reported.
+func TestStopContinuesPastFailedWatcher(t *testing.T) {
+	ctl := gomock.NewController(t)
+	defer ctl.Finish()
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
+
+	failing := mock.NewMockIWatcher(ctl)
+	healthy := mock.NewMockIWatcher(ctl)
+
+	mgr := NewWatcherManager(kcfg.DefaultFilterMapMaxEntries, false, 0)
+	mgr.Watchers = []IWatcher{failing, healthy}
+
+	failing.EXPECT().Stop(gomock.Any()).Return(errInitFailed).Times(1)
+	// The second watcher must still be stopped.
+	healthy.EXPECT().Stop(gomock.Any()).Return(nil).Times(1)
+
+	err := mgr.Stop(context.Background())
+	require.ErrorIs(t, err, errInitFailed)
+}
+
+// A watcher must reconcile once at startup, not wait for the first tick.
+func TestRunWatcherInitialReconcile(t *testing.T) {
+	ctl := gomock.NewController(t)
+	defer ctl.Finish()
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
+
+	w := mock.NewMockIWatcher(ctl)
+	mgr := NewWatcherManager(kcfg.DefaultFilterMapMaxEntries, false, time.Hour) // no tick fires during the test
+	mgr.Watchers = []IWatcher{w}
+
+	refreshed := make(chan struct{}, 1)
+	w.EXPECT().Init(gomock.Any()).Return(nil).Times(1)
+	w.EXPECT().Refresh(gomock.Any()).DoAndReturn(func(context.Context) error {
+		select {
+		case refreshed <- struct{}{}:
+		default:
+		}
+		return nil
+	}).Times(1)
+	w.EXPECT().Stop(gomock.Any()).Return(nil).Times(1)
+
+	require.NoError(t, mgr.Start(context.Background()))
+	select {
+	case <-refreshed:
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected a reconcile at startup, before the first tick")
+	}
+	require.NoError(t, mgr.Stop(context.Background()))
+}
+
+// A failing Refresh must not kill the watcher goroutine; the next tick retries.
+func TestRunWatcherSurvivesRefreshErrors(t *testing.T) {
+	ctl := gomock.NewController(t)
+	defer ctl.Finish()
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
+
+	w := mock.NewMockIWatcher(ctl)
+	mgr := NewWatcherManager(kcfg.DefaultFilterMapMaxEntries, false, 10*time.Millisecond)
+	mgr.Watchers = []IWatcher{w}
+
+	var calls atomic.Int32
+	w.EXPECT().Init(gomock.Any()).Return(nil).Times(1)
+	w.EXPECT().Refresh(gomock.Any()).DoAndReturn(func(context.Context) error {
+		calls.Add(1)
+		return errInitFailed
+	}).AnyTimes()
+	w.EXPECT().Stop(gomock.Any()).Return(nil).Times(1)
+
+	require.NoError(t, mgr.Start(context.Background()))
+	require.Eventually(t, func() bool { return calls.Load() >= 3 }, 2*time.Second, 5*time.Millisecond,
+		"refresh errors must be logged and retried, not terminate the watcher")
+	require.NoError(t, mgr.Stop(context.Background()))
+}
+
 func TestWatcherStopWithoutStart(t *testing.T) {
 	ctl := gomock.NewController(t)
 	defer ctl.Finish()
 	log.SetupZapLogger(log.GetDefaultLogOpts())
 
-	mgr := NewWatcherManager(kcfg.DefaultFilterMapMaxEntries)
+	mgr := NewWatcherManager(kcfg.DefaultFilterMapMaxEntries, false, 0)
 
 	err := mgr.Stop(context.Background())
 	require.Nil(t, err, "Expected no error when stopping watcher manager without starting it")

--- a/pkg/module/metrics/metrics_module.go
+++ b/pkg/module/metrics/metrics_module.go
@@ -537,10 +537,11 @@ func handlePodEvent(
 		m.dirtyPods.ToAdd(podCacheEntry.IP.String(), podCacheEntry)
 	case cache.EventTypePodDeleted:
 		// Guard against spurious DELETE events during pod churn / IP reuse.
-		// The cache (pkg/controllers/cache/cache.go) updates its maps synchronously
-		// (epMap/ipToEpKey) and then publishes events asynchronously via a goroutine.
-		// So when we process this DELETE, if a new pod already reused the IP, the
-		// cache will still contain a valid entry. Deleting would incorrectly remove it.
+		// The cache (pkg/controllers/cache/cache.go) commits its maps
+		// (epMap/ipToEpKey) before publishing, and delivery happens later on this
+		// subscriber's drain goroutine. So when we process this DELETE, if a new
+		// pod already reused the IP, the cache will still contain a valid entry.
+		// Deleting would incorrectly remove it.
 		if endpoint := m.daemonCache.GetPodByIP(ip.String()); endpoint != nil {
 			m.l.Debug("Ignoring DELETE for reused IP — pod still exists in cache",
 				zap.String("deleted pod", pod.NamespacedName()),

--- a/pkg/plugin/ebpftest/helpers.go
+++ b/pkg/plugin/ebpftest/helpers.go
@@ -22,9 +22,9 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-// RequirePrivileged skips the test if the current process lacks BPF privileges.
-// It checks for CAP_BPF or CAP_SYS_ADMIN in the effective capability set.
-func RequirePrivileged(t *testing.T) {
+// RequirePrivileged skips the test/benchmark if the current process lacks BPF
+// privileges. It checks for CAP_BPF or CAP_SYS_ADMIN in the effective capability set.
+func RequirePrivileged(t testing.TB) {
 	t.Helper()
 
 	if os.Geteuid() == 0 {

--- a/pkg/plugin/packetparser/mocks/mock_types_linux.go
+++ b/pkg/plugin/packetparser/mocks/mock_types_linux.go
@@ -12,10 +12,63 @@ package mocks
 import (
 	reflect "reflect"
 
+	link "github.com/cilium/ebpf/link"
 	tc "github.com/florianl/go-tc"
 	netlink "github.com/mdlayher/netlink"
 	gomock "go.uber.org/mock/gomock"
 )
+
+// MocktcxLink is a mock of tcxLink interface.
+type MocktcxLink struct {
+	ctrl     *gomock.Controller
+	recorder *MocktcxLinkMockRecorder
+}
+
+// MocktcxLinkMockRecorder is the mock recorder for MocktcxLink.
+type MocktcxLinkMockRecorder struct {
+	mock *MocktcxLink
+}
+
+// NewMocktcxLink creates a new mock instance.
+func NewMocktcxLink(ctrl *gomock.Controller) *MocktcxLink {
+	mock := &MocktcxLink{ctrl: ctrl}
+	mock.recorder = &MocktcxLinkMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MocktcxLink) EXPECT() *MocktcxLinkMockRecorder {
+	return m.recorder
+}
+
+// Close mocks base method.
+func (m *MocktcxLink) Close() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Close")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Close indicates an expected call of Close.
+func (mr *MocktcxLinkMockRecorder) Close() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MocktcxLink)(nil).Close))
+}
+
+// Info mocks base method.
+func (m *MocktcxLink) Info() (*link.Info, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Info")
+	ret0, _ := ret[0].(*link.Info)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Info indicates an expected call of Info.
+func (mr *MocktcxLinkMockRecorder) Info() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Info", reflect.TypeOf((*MocktcxLink)(nil).Info))
+}
 
 // Mockqdisc is a mock of qdisc interface.
 type Mockqdisc struct {
@@ -103,6 +156,21 @@ func (m *Mockfilter) Add(info *tc.Object) error {
 func (mr *MockfilterMockRecorder) Add(info any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Add", reflect.TypeOf((*Mockfilter)(nil).Add), info)
+}
+
+// Get mocks base method.
+func (m *Mockfilter) Get(info *tc.Msg) ([]tc.Object, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Get", info)
+	ret0, _ := ret[0].([]tc.Object)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Get indicates an expected call of Get.
+func (mr *MockfilterMockRecorder) Get(info any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*Mockfilter)(nil).Get), info)
 }
 
 // Mocknltc is a mock of nltc interface.

--- a/pkg/plugin/packetparser/packetparser_ebpf_test.go
+++ b/pkg/plugin/packetparser/packetparser_ebpf_test.go
@@ -7,24 +7,29 @@ package packetparser
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"os"
 	"os/exec"
 	"path"
 	"runtime"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/link"
 	"github.com/cilium/ebpf/perf"
 	"github.com/cilium/ebpf/ringbuf"
+	tc "github.com/florianl/go-tc"
 	"github.com/gopacket/gopacket/layers"
 	"github.com/microsoft/retina/pkg/loader"
 	"github.com/microsoft/retina/pkg/log"
 	"github.com/microsoft/retina/pkg/plugin/ebpftest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/vishvananda/netlink"
 )
 
 const (
@@ -51,7 +56,7 @@ const (
 )
 
 // loadTestObjects loads the packetparser eBPF programs and maps for testing.
-func loadTestObjects(t *testing.T) (*packetparserObjects, *perf.Reader) {
+func loadTestObjects(t testing.TB) (*packetparserObjects, *perf.Reader) {
 	t.Helper()
 	ebpftest.RequirePrivileged(t)
 
@@ -1298,4 +1303,260 @@ func TestRingBufReaderWrapper(t *testing.T) {
 	// After closing, Read() should return ringbuf.ErrClosed
 	_, err = wrapper.Read()
 	assert.ErrorIs(t, err, ringbuf.ErrClosed)
+}
+
+// TestTCXLinkLivenessAcrossInterfaceDelete verifies the attachment liveness
+// probe against a real kernel: a TCX link on a live veth reports its interface
+// index, and reports Ifindex 0 (defunct) once the veth is deleted — the signal
+// createQdiscAndAttach uses to drop a stale attachment record and re-attach when
+// an interface index is reused. Requires kernel 6.6+ (TCX) and NET_ADMIN.
+func TestTCXLinkLivenessAcrossInterfaceDelete(t *testing.T) {
+	objs, _ := loadTestObjects(t)
+
+	la := netlink.NewLinkAttrs()
+	la.Name = "rtnlive0"
+	veth := &netlink.Veth{LinkAttrs: la, PeerName: "rtnlive0p"}
+	// Remove any leftover from a previously failed run.
+	if old, err := netlink.LinkByName(la.Name); err == nil {
+		_ = netlink.LinkDel(old)
+	}
+	require.NoError(t, netlink.LinkAdd(veth))
+	deleted := false
+	t.Cleanup(func() {
+		if !deleted {
+			_ = netlink.LinkDel(veth)
+		}
+	})
+
+	created, err := netlink.LinkByName(la.Name)
+	require.NoError(t, err)
+	idx := created.Attrs().Index
+
+	tcx, err := link.AttachTCX(link.TCXOptions{
+		Program:   objs.EndpointIngressFilter,
+		Attach:    ebpf.AttachTCXIngress,
+		Interface: idx,
+		Anchor:    link.Head(),
+	})
+	if errors.Is(err, ebpf.ErrNotSupported) {
+		t.Skipf("TCX not supported on this kernel: %v", err)
+	}
+	require.NoError(t, err)
+	t.Cleanup(func() { tcx.Close() })
+
+	// Alive: the probe sees the real interface index.
+	info, err := tcx.Info()
+	require.NoError(t, err)
+	tcxInfo := info.TCX()
+	require.NotNil(t, tcxInfo, "expected TCX metadata on a TCX link")
+	assert.Equal(t, uint32(idx), tcxInfo.Ifindex, "live link must report its interface index")
+	assert.True(t, tcxLinkAlive(tcx), "link on a live interface must probe alive")
+
+	// Delete the interface: the kernel auto-detaches, and the surviving link
+	// handle must probe defunct.
+	require.NoError(t, netlink.LinkDel(veth))
+	deleted = true
+
+	assert.Eventually(t, func() bool { return !tcxLinkAlive(tcx) },
+		2*time.Second, 10*time.Millisecond,
+		"link must probe dead after its interface is deleted")
+}
+
+// TestCreateQdiscAndAttachTC exercises the real legacy-TC path
+// (createQdiscAndAttach -> attachViaTC -> go-tc clsact qdisc + BPF filters) and
+// the real tcAttachmentAlive probe against a live kernel. Requires NET_ADMIN.
+func TestCreateQdiscAndAttachTC(t *testing.T) {
+	objs, _ := loadTestObjects(t)
+
+	// This binary (-tags=ebpf) also compiles the unit tests, which mutate these
+	// package-var seams to gomock fakes without restoring them. Reset them to the
+	// real implementations so this test drives the actual kernel, regardless of
+	// test execution order.
+	getQdisc = func(tcnl nltc) qdisc { return tcnl.Qdisc() }
+	getFilter = func(tcnl nltc) filter { return tcnl.Filter() }
+	tcOpen = func(config *tc.Config) (nltc, error) { return tc.Open(config) }
+	getFD = func(e *ebpf.Program) int { return e.FD() }
+
+	la := netlink.NewLinkAttrs()
+	la.Name = "rtntcatt"
+	veth := &netlink.Veth{LinkAttrs: la, PeerName: "rtntcattp"}
+	if old, err := netlink.LinkByName(la.Name); err == nil {
+		_ = netlink.LinkDel(old)
+	}
+	require.NoError(t, netlink.LinkAdd(veth))
+	deleted := false
+	t.Cleanup(func() {
+		if !deleted {
+			_ = netlink.LinkDel(veth)
+		}
+	})
+
+	created, err := netlink.LinkByName(la.Name)
+	require.NoError(t, err)
+	attrs := *created.Attrs()
+
+	p := &packetParser{
+		l:                   log.Logger().Named("test"),
+		objs:                objs,
+		attachmentMap:       &sync.Map{},
+		endpointIngressInfo: &ebpf.ProgramInfo{Name: "endpoint_ingress"},
+		endpointEgressInfo:  &ebpf.ProgramInfo{Name: "endpoint_egress"},
+		tcxSupported:        false, // force the legacy TC path
+	}
+	t.Cleanup(func() { _ = p.cleanAll() })
+
+	p.createQdiscAndAttach(attrs, Veth)
+
+	value, ok := p.attachmentMap.Load(ifaceToKey(attrs))
+	require.True(t, ok, "expected a recorded attachment after TC attach")
+	av := value.(*attachmentValue)
+	require.Equal(t, attachmentTypeTC, av.attachmentType, "should attach via legacy TC when TCX is disabled")
+	assert.True(t, p.attachmentAlive(av), "freshly attached clsact qdisc must probe alive")
+
+	// A re-assert while live must be a no-op (idempotent skip).
+	p.createQdiscAndAttach(attrs, Veth)
+	value2, _ := p.attachmentMap.Load(ifaceToKey(attrs))
+	assert.Same(t, av, value2.(*attachmentValue), "live re-assert must not re-attach")
+
+	// Delete the interface: the kernel removes the clsact qdisc, so the probe
+	// must report the attachment dead.
+	require.NoError(t, netlink.LinkDel(veth))
+	deleted = true
+	assert.Eventually(t, func() bool { return !p.attachmentAlive(av) },
+		2*time.Second, 10*time.Millisecond,
+		"attachment must probe dead after its interface (and clsact qdisc) is deleted")
+}
+
+// BenchmarkTCLivenessProbe measures the cost of a single legacy-TC liveness
+// probe (attachmentAlive -> a targeted per-ifindex filter query on the clsact
+// ingress hook) as the number of attached interfaces grows. Flat ns/op across N
+// shows the per-probe cost is O(1), keeping a full re-assert sweep over N
+// attachments at O(N) — a system-wide qdisc dump here would make the sweep
+// O(N^2). It is not run by CI (needs -bench and NET_ADMIN); run on a privileged
+// host with:
+//
+//	go test -tags=ebpf -run='^$' -bench=BenchmarkTCLivenessProbe ./pkg/plugin/packetparser/
+//
+// TCX's probe is one per-link Info() syscall, also O(1) (see its benchmark).
+func BenchmarkTCLivenessProbe(b *testing.B) {
+	objs, _ := loadTestObjects(b)
+
+	// -tags=ebpf also compiles the mock-mutating unit tests; use the real impls.
+	getQdisc = func(tcnl nltc) qdisc { return tcnl.Qdisc() }
+	getFilter = func(tcnl nltc) filter { return tcnl.Filter() }
+	tcOpen = func(config *tc.Config) (nltc, error) { return tc.Open(config) }
+	getFD = func(e *ebpf.Program) int { return e.FD() }
+
+	for _, n := range []int{50, 100, 200} {
+		b.Run(fmt.Sprintf("N=%d", n), func(b *testing.B) {
+			p := &packetParser{
+				l:                   log.Logger().Named("bench"),
+				objs:                objs,
+				attachmentMap:       &sync.Map{},
+				endpointIngressInfo: &ebpf.ProgramInfo{Name: "endpoint_ingress"},
+				endpointEgressInfo:  &ebpf.ProgramInfo{Name: "endpoint_egress"},
+				tcxSupported:        false, // force legacy TC
+			}
+			var veths []*netlink.Veth
+			b.Cleanup(func() {
+				_ = p.cleanAll()
+				for _, v := range veths {
+					_ = netlink.LinkDel(v)
+				}
+			})
+
+			// Setup (untimed): create and attach N veths via the real TC path.
+			var probeKey attachmentKey
+			for i := 0; i < n; i++ {
+				la := netlink.NewLinkAttrs()
+				la.Name = fmt.Sprintf("rtnbench%d", i)
+				veth := &netlink.Veth{LinkAttrs: la, PeerName: fmt.Sprintf("rtnbenchp%d", i)}
+				if old, err := netlink.LinkByName(la.Name); err == nil {
+					_ = netlink.LinkDel(old)
+				}
+				require.NoError(b, netlink.LinkAdd(veth))
+				veths = append(veths, veth)
+				created, err := netlink.LinkByName(la.Name)
+				require.NoError(b, err)
+				attrs := *created.Attrs()
+				p.createQdiscAndAttach(attrs, Veth)
+				probeKey = ifaceToKey(attrs)
+			}
+			val, ok := p.attachmentMap.Load(probeKey)
+			require.True(b, ok, "expected an attachment to probe")
+			av := val.(*attachmentValue)
+
+			// Timed: one liveness probe per iteration. b.Loop keeps the setup
+			// above out of the measured region and runs it only once.
+			for b.Loop() {
+				if !p.attachmentAlive(av) {
+					b.Fatal("attachment should probe alive")
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkTCXLivenessProbe is the TCX counterpart of BenchmarkTCLivenessProbe.
+// A TCX probe is a single per-link Info() syscall, so ns/op should stay flat as
+// N grows. Both transports now probe O(1); TCX remains cheaper (no netlink
+// round-trips). Requires kernel 6.6+ (TCX) and NET_ADMIN.
+// Run alongside the TC benchmark:
+//
+//	go test -tags=ebpf -run='^$' -bench='BenchmarkTC.*LivenessProbe' ./pkg/plugin/packetparser/
+func BenchmarkTCXLivenessProbe(b *testing.B) {
+	objs, _ := loadTestObjects(b)
+	if !isTCXSupported() {
+		b.Skip("TCX not supported on this kernel")
+	}
+	// The TCX path uses link.AttachTCX directly and none of the mutable TC seams,
+	// so no reset is needed here.
+
+	for _, n := range []int{50, 100, 200} {
+		b.Run(fmt.Sprintf("N=%d", n), func(b *testing.B) {
+			p := &packetParser{
+				l:                   log.Logger().Named("bench"),
+				objs:                objs,
+				attachmentMap:       &sync.Map{},
+				endpointIngressInfo: &ebpf.ProgramInfo{Name: "endpoint_ingress"},
+				endpointEgressInfo:  &ebpf.ProgramInfo{Name: "endpoint_egress"},
+				tcxSupported:        true, // force TCX
+			}
+			var veths []*netlink.Veth
+			b.Cleanup(func() {
+				_ = p.cleanAll()
+				for _, v := range veths {
+					_ = netlink.LinkDel(v)
+				}
+			})
+
+			// Setup (untimed): create and attach N veths via the real TCX path.
+			var probeKey attachmentKey
+			for i := 0; i < n; i++ {
+				la := netlink.NewLinkAttrs()
+				la.Name = fmt.Sprintf("rtnxbench%d", i)
+				veth := &netlink.Veth{LinkAttrs: la, PeerName: fmt.Sprintf("rtnxbenchp%d", i)}
+				if old, err := netlink.LinkByName(la.Name); err == nil {
+					_ = netlink.LinkDel(old)
+				}
+				require.NoError(b, netlink.LinkAdd(veth))
+				veths = append(veths, veth)
+				created, err := netlink.LinkByName(la.Name)
+				require.NoError(b, err)
+				attrs := *created.Attrs()
+				p.createQdiscAndAttach(attrs, Veth)
+				probeKey = ifaceToKey(attrs)
+			}
+			val, ok := p.attachmentMap.Load(probeKey)
+			require.True(b, ok, "expected an attachment to probe")
+			av := val.(*attachmentValue)
+			require.Equal(b, attachmentTypeTCX, av.attachmentType, "setup must use the TCX path")
+
+			for b.Loop() {
+				if !p.attachmentAlive(av) {
+					b.Fatal("attachment should probe alive")
+				}
+			}
+		})
+	}
 }

--- a/pkg/plugin/packetparser/packetparser_linux.go
+++ b/pkg/plugin/packetparser/packetparser_linux.go
@@ -341,6 +341,7 @@ func (p *packetParser) Start(ctx context.Context) error {
 	}
 
 	p.l.Info("Starting packet parser")
+	p.stopping.Store(false) // may be set from a prior Stop on this instance
 
 	p.l.Info("setting up enricher since pod level is enabled")
 	// Set up enricher.
@@ -396,6 +397,23 @@ func (p *packetParser) Stop() error {
 	// Get pubsubs instance
 	ps := pubsub.New()
 
+	// Quiesce the endpoint callback FIRST: mark stopping (deliveries become
+	// no-ops), unsubscribe, then wait out any delivery already in flight —
+	// pubsub's Unsubscribe does not wait for one. Only then is it safe to close
+	// programs and clean attachments; tearing down first would let an in-flight
+	// attach use closed programs or Store after cleanAll, leaking a live link.
+	p.stopping.Store(true)
+	if p.callbackID != "" {
+		if err := ps.Unsubscribe(common.PubSubEndpoints, p.callbackID); err != nil {
+			p.l.Error("Error unregistering callback for packetParser", zap.Error(err))
+		}
+		// Reset callback ID.
+		p.callbackID = ""
+	}
+	p.cbMu.Lock()
+	p.cbMu.Unlock() //nolint:staticcheck,gocritic // empty critical section is the point: a barrier for an in-flight callback
+	p.l.Debug("Quiesced endpoint callback")
+
 	// Stop perf reader.
 	if p.reader != nil {
 		if err := p.reader.Close(); err != nil {
@@ -419,15 +437,6 @@ func (p *packetParser) Stop() error {
 	}
 	p.l.Debug("Stopped map/progs")
 
-	// Unregister callback.
-	if p.callbackID != "" {
-		if err := ps.Unsubscribe(common.PubSubEndpoints, p.callbackID); err != nil {
-			p.l.Error("Error unregistering callback for packetParser", zap.Error(err))
-		}
-		// Reset callback ID.
-		p.callbackID = ""
-	}
-
 	if err := p.cleanAll(); err != nil {
 		p.l.Error("Error cleaning", zap.Error(err))
 		return err
@@ -444,6 +453,10 @@ func (p *packetParser) SetupChannel(ch chan *v1.Event) error {
 
 // cleanAll is NOT thread safe.
 // Not required for now.
+// Accepted gap (legacy TC only): the qdisc delete is unconditional, so if an
+// attach rode on a clsact another agent created (ErrExist-tolerated), stopping
+// Retina removes that agent's filters too. TCX teardown closes only our own
+// links.
 func (p *packetParser) cleanAll() error {
 	if p.attachmentMap == nil {
 		return nil
@@ -471,7 +484,7 @@ func (p *packetParser) clean(rtnl nltc, qdisc *tc.Object) {
 	// Warning, not error. Clean is best effort.
 	if rtnl != nil {
 		if err := getQdisc(rtnl).Delete(qdisc); err != nil && !errors.Is(err, tc.ErrNoArg) {
-			p.l.Debug("could not delete egress qdisc", zap.Error(err))
+			p.l.Debug("could not delete clsact qdisc", zap.Error(err))
 		}
 		if err := rtnl.Close(); err != nil {
 			p.l.Warn("could not close rtnetlink socket", zap.Error(err))
@@ -479,8 +492,85 @@ func (p *packetParser) clean(rtnl nltc, qdisc *tc.Object) {
 	}
 }
 
+// attachmentAlive reports whether a recorded attachment still exists in the
+// kernel. Both transports are probed at the same granularity (interface-level):
+// TCX via the link's Ifindex, legacy TC via the presence of a bpf filter on
+// the clsact ingress hook.
+// The kernel tears both down when the interface is deleted, so a probe that
+// comes back dead means the record is stale (interface gone, possibly with its
+// index already reused) and must be re-attached.
+func (p *packetParser) attachmentAlive(v *attachmentValue) bool {
+	if v.attachmentType == attachmentTypeTCX {
+		return tcxLinkAlive(v.tcxIngressLink) && tcxLinkAlive(v.tcxEgressLink)
+	}
+	return p.tcAttachmentAlive(v)
+}
+
+// tcAttachmentAlive reports whether a BPF filter still exists on the recorded
+// interface's clsact ingress hook. It queries only that interface+parent (O(1)),
+// rather than dumping every qdisc system-wide, so a re-assert sweep over N
+// attachments stays O(N) instead of O(N^2). The kernel removes the clsact qdisc
+// and its filters when the interface is deleted, so the filter's absence means
+// the attachment is defunct. A probe error (e.g. the socket is unusable) is
+// treated as dead so we re-attach rather than trust a stale record.
+//
+// The probe matches on presence (any bpf filter), deliberately no stronger:
+// the repair path is an EEXIST-tolerant Add, which can only fix "no filter
+// there" — a probe that detects more than Add can repair (e.g. matching our
+// program ID) turns unrepairable states into per-refresh re-attach churn that
+// accumulates duplicate auto-handle filters. Accepted, documented gaps of the
+// legacy-TC fallback, all absent under TCX:
+//   - unclean agent restart: the surviving filters satisfy the probe; the
+//     first re-attach leaves one duplicate ingress filter and the egress hook
+//     keeps the dead process's program until the veth churns.
+//   - index reuse where the new occupant carries another agent's bpf filter:
+//     probes false-alive, so that veth stays unmonitored until it churns.
+//   - another legacy-TC agent on the same hooks contends for the conventional
+//     (prio 1) slots.
+func (p *packetParser) tcAttachmentAlive(v *attachmentValue) bool {
+	if v.tc == nil || v.qdisc == nil {
+		return false
+	}
+	filters, err := getFilter(v.tc).Get(&tc.Msg{
+		Family:  unix.AF_UNSPEC,
+		Ifindex: v.qdisc.Ifindex,
+		Parent:  helper.BuildHandle(0xFFFF, tc.HandleMinIngress), //nolint:gomnd // clsact ingress parent, matches attachViaTC
+	})
+	if err != nil {
+		p.l.Debug("could not query filters for TC liveness probe", zap.Error(err))
+		return false
+	}
+	for i := range filters {
+		if filters[i].Kind == "bpf" {
+			return true
+		}
+	}
+	return false
+}
+
+// tcxLinkAlive reports whether a TCX link is still attached to a live
+// interface. The kernel auto-detaches TCX links when their interface is
+// deleted; the surviving defunct link reports Ifindex 0.
+func tcxLinkAlive(l tcxLink) bool {
+	if l == nil {
+		return false
+	}
+	info, err := l.Info()
+	if err != nil {
+		return false
+	}
+	return tcxInfoAlive(info.TCX())
+}
+
+// tcxInfoAlive is the liveness decision on a link's TCX metadata: Ifindex 0
+// means the kernel cleared the device (interface deleted). Nil metadata means
+// liveness cannot be determined; treat as alive rather than churn attachments.
+func tcxInfoAlive(tcx *link.TCXInfo) bool {
+	return tcx == nil || tcx.Ifindex != 0
+}
+
 // cleanTCX closes TCX links. This is best effort.
-func (p *packetParser) cleanTCX(ingressLink, egressLink link.Link) {
+func (p *packetParser) cleanTCX(ingressLink, egressLink tcxLink) {
 	if ingressLink != nil {
 		if err := ingressLink.Close(); err != nil {
 			p.l.Debug("could not close ingress TCX link", zap.Error(err))
@@ -529,6 +619,15 @@ func isTCXSupported() bool {
 }
 
 func (p *packetParser) endpointWatcherCallbackFn(obj interface{}) {
+	// Serialize with Stop: a delivery already in flight when Stop unsubscribes
+	// must finish (or become a no-op) before Stop tears down programs and maps,
+	// otherwise a racing attach can Store after cleanAll and leak a live link.
+	p.cbMu.Lock()
+	defer p.cbMu.Unlock()
+	if p.stopping.Load() {
+		return
+	}
+
 	// Contract is that we will receive an endpoint event pointer.
 	event := obj.(*endpoint.EndpointEvent)
 	if event == nil {
@@ -554,8 +653,15 @@ func (p *packetParser) endpointWatcherCallbackFn(obj interface{}) {
 			v := value.(*attachmentValue)
 			if v.attachmentType == attachmentTypeTCX {
 				p.cleanTCX(v.tcxIngressLink, v.tcxEgressLink)
-			} else {
-				p.clean(v.tc, v.qdisc)
+			} else if v.tc != nil {
+				// Close only the socket — do NOT delete the qdisc. A delete event
+				// means the interface is gone (the kernel already destroyed our
+				// qdisc) or its index was reused (the watcher's reuse detection
+				// publishes a delete for a live index): a clsact present at this
+				// ifindex belongs to the new occupant, possibly another agent.
+				if err := v.tc.Close(); err != nil {
+					p.l.Warn("could not close rtnetlink socket", zap.Error(err))
+				}
 			}
 			// Delete from map.
 			p.attachmentMap.Delete(ifaceKey)
@@ -572,6 +678,35 @@ func (p *packetParser) endpointWatcherCallbackFn(obj interface{}) {
 // depending on kernel support and configuration.
 // Only support interfaces of type veth and device.
 func (p *packetParser) createQdiscAndAttach(iface netlink.LinkAttrs, ifaceType interfaceType) {
+	// Idempotent: skip if already attached so repeated reconcile events don't
+	// double-attach and leak links. Presence alone isn't enough: verify the
+	// recorded attachment is still live in the kernel. A record can outlive its
+	// attachment — the interface was deleted and its index reused before we saw
+	// the delete, or the programs were detached externally — and trusting it
+	// would leave the current occupant unmonitored until it next churns. The
+	// level-triggered re-assert redelivers creates every refresh, so dropping a
+	// stale record here self-heals within one refresh interval.
+	if value, ok := p.attachmentMap.Load(ifaceToKey(iface)); ok {
+		v := value.(*attachmentValue)
+		if p.attachmentAlive(v) {
+			return
+		}
+		p.l.Warn("stale attachment record; re-attaching",
+			zap.String("interface", iface.Name), zap.Int("index", iface.Index))
+		// Best effort: release the defunct handles before re-attaching so we don't
+		// leak the TCX links or the TC rtnetlink socket. For TC, close only the
+		// socket — do NOT delete the qdisc: on index reuse the clsact at this
+		// ifindex may belong to the interface's new occupant (another agent), and
+		// attachViaTC tolerates an existing qdisc anyway.
+		if v.attachmentType == attachmentTypeTCX {
+			p.cleanTCX(v.tcxIngressLink, v.tcxEgressLink)
+		} else if v.tc != nil {
+			if err := v.tc.Close(); err != nil {
+				p.l.Warn("could not close stale rtnetlink socket", zap.Error(err))
+			}
+		}
+		p.attachmentMap.Delete(ifaceToKey(iface))
+	}
 	p.l.Debug("Starting attachment", zap.String("interface", iface.Name))
 
 	if p.tcxSupported {
@@ -642,7 +777,6 @@ func (p *packetParser) attachViaTC(iface netlink.LinkAttrs, ifaceType interfaceT
 	var (
 		ingressProgram, egressProgram *ebpf.Program
 		ingressInfo, egressInfo       *ebpf.ProgramInfo
-		err                           error
 	)
 
 	switch ifaceType {
@@ -668,8 +802,10 @@ func (p *packetParser) attachViaTC(iface netlink.LinkAttrs, ifaceType interfaceT
 		return
 	}
 	// set extended acknowledge option for more detailed error messages.
-	if err = rtnl.SetOption(nl.ExtendedAcknowledge, true); err != nil {
-		p.l.Warn("could not set extended acknowledge option", zap.Error(err))
+	// Non-fatal: must not feed the cleanup defer below (a poisoned err would tear
+	// down a successful attach), so keep its error local.
+	if optErr := rtnl.SetOption(nl.ExtendedAcknowledge, true); optErr != nil {
+		p.l.Warn("could not set extended acknowledge option", zap.Error(optErr))
 	}
 
 	// Create a qdisc of type clsact on the tunnel interface.
@@ -688,13 +824,32 @@ func (p *packetParser) attachViaTC(iface netlink.LinkAttrs, ifaceType interfaceT
 			Kind: "clsact",
 		},
 	}
+	// Release the socket and undo the qdisc on any failed exit. Keyed on explicit
+	// flags, not err: the failure returns below shadow err, so an err-keyed defer
+	// would never fire — leaking one rtnl fd per failed attach, once per refresh
+	// under the level-triggered re-assert. Delete only a qdisc we created — a
+	// pre-existing clsact may belong to another agent, and deleting it would tear
+	// down their filters too.
+	attached := false
+	createdQdisc := false
 	defer func() {
-		if err != nil {
-			p.clean(rtnl, clsactQdisc)
+		if attached {
+			return
+		}
+		if createdQdisc {
+			if err := getQdisc(rtnl).Delete(clsactQdisc); err != nil && !errors.Is(err, tc.ErrNoArg) {
+				p.l.Debug("could not delete clsact qdisc", zap.Error(err))
+			}
+		}
+		if err := rtnl.Close(); err != nil {
+			p.l.Warn("could not close rtnetlink socket", zap.Error(err))
 		}
 	}()
 	// Install Qdisc on interface.
-	if err := getQdisc(rtnl).Add(clsactQdisc); err != nil && !errors.Is(err, os.ErrExist) {
+	switch err := getQdisc(rtnl).Add(clsactQdisc); {
+	case err == nil:
+		createdQdisc = true
+	case !errors.Is(err, os.ErrExist):
 		p.l.Error("could not assign clsact to tunnel interface", zap.String("interface", iface.Name), zap.Error(err))
 		return
 	}
@@ -750,6 +905,7 @@ func (p *packetParser) attachViaTC(iface netlink.LinkAttrs, ifaceType interfaceT
 		tc:             rtnl,
 		qdisc:          clsactQdisc,
 	})
+	attached = true
 
 	p.l.Debug("Successfully attached BPF programs using traditional TC", zap.String("interface", iface.Name))
 }

--- a/pkg/plugin/packetparser/packetparser_linux_test.go
+++ b/pkg/plugin/packetparser/packetparser_linux_test.go
@@ -18,6 +18,7 @@ import (
 
 	v1 "github.com/cilium/cilium/pkg/hubble/api/v1"
 	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/link"
 	"github.com/cilium/ebpf/ringbuf"
 	tc "github.com/florianl/go-tc"
 	nl "github.com/mdlayher/netlink"
@@ -79,6 +80,8 @@ func (mr *mockPerfReaderRecorder) Close() *gomock.Call {
 
 var errTestRead = errors.New("error")
 
+var errLinkDefunct = errors.New("link is defunct")
+
 var (
 	cfgPodLevelEnabled = &kcfg.Config{
 		EnablePodLevel:           true,
@@ -136,8 +139,8 @@ func TestCleanAll(t *testing.T) {
 		return mq
 	}
 
-	p.attachmentMap.Store(attachmentKey{"test", "test", 1}, &attachmentValue{tc: mrtnl, qdisc: &tc.Object{}})
-	p.attachmentMap.Store(attachmentKey{"test2", "test2", 2}, &attachmentValue{tc: mrtnl, qdisc: &tc.Object{}})
+	p.attachmentMap.Store(attachmentKey{1}, &attachmentValue{tc: mrtnl, qdisc: &tc.Object{}})
+	p.attachmentMap.Store(attachmentKey{2}, &attachmentValue{tc: mrtnl, qdisc: &tc.Object{}})
 
 	assert.Nil(t, p.cleanAll())
 
@@ -182,7 +185,7 @@ func TestClean(t *testing.T) {
 }
 
 func TestCleanWithErrors(t *testing.T) {
-	log.SetupZapLogger(log.GetDefaultLogOpts())
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
 
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -209,7 +212,7 @@ func TestCleanWithErrors(t *testing.T) {
 }
 
 func TestEndpointWatcherCallbackFn_EndpointDeleted(t *testing.T) {
-	log.SetupZapLogger(log.GetDefaultLogOpts())
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -229,9 +232,18 @@ func TestEndpointWatcherCallbackFn_EndpointDeleted(t *testing.T) {
 	}
 	key := ifaceToKey(linkAttr)
 
+	// The delete path must close only the stale socket — never delete the qdisc:
+	// a delete event means the interface is gone or its index was reused, so a
+	// clsact at this ifindex may belong to the new occupant. A strict qdisc mock
+	// with no expectations turns any Delete into a test failure.
+	mq := mocks.NewMockqdisc(ctrl)
+	getQdisc = func(nltc) qdisc { return mq }
+	oldRtnl := mocks.NewMocknltc(ctrl)
+	oldRtnl.EXPECT().Close().Return(nil).Times(1)
+
 	// Pre-populate both maps to simulate existing interface
 	p.interfaceLockMap.Store(key, &sync.Mutex{})
-	p.attachmentMap.Store(key, &attachmentValue{tc: nil, qdisc: &tc.Object{}})
+	p.attachmentMap.Store(key, &attachmentValue{tc: oldRtnl, qdisc: &tc.Object{}})
 
 	// Create EndpointDeleted event.
 	e := &endpoint.EndpointEvent{
@@ -251,7 +263,7 @@ func TestEndpointWatcherCallbackFn_EndpointDeleted(t *testing.T) {
 }
 
 func TestCreateQdiscAndAttach(t *testing.T) {
-	log.SetupZapLogger(log.GetDefaultLogOpts())
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -281,7 +293,7 @@ func TestCreateQdiscAndAttach(t *testing.T) {
 		return 1
 	}
 
-	pObj := &packetparserObjects{} //nolint:typecheck
+	pObj := &packetparserObjects{} //nolint:typecheck // generated bpf2go type
 	pObj.EndpointIngressFilter = &ebpf.Program{}
 	pObj.EndpointEgressFilter = &ebpf.Program{}
 
@@ -308,6 +320,7 @@ func TestCreateQdiscAndAttach(t *testing.T) {
 		Name:         "test",
 		HardwareAddr: []byte("test"),
 		NetNsID:      1,
+		Index:        1,
 	}
 	// Test veth.
 	p.createQdiscAndAttach(linkAttr, Veth)
@@ -322,6 +335,7 @@ func TestCreateQdiscAndAttach(t *testing.T) {
 		Name:         "test2",
 		HardwareAddr: []byte("test2"),
 		NetNsID:      2,
+		Index:        2,
 	}
 	// Test Device.
 	p.createQdiscAndAttach(linkAttr2, Device)
@@ -331,8 +345,434 @@ func TestCreateQdiscAndAttach(t *testing.T) {
 	assert.True(t, ok)
 }
 
+// fakeTCXLink fakes a stored TCX link for the liveness check.
+type fakeTCXLink struct {
+	info   *link.Info
+	err    error
+	closed bool
+}
+
+func (f *fakeTCXLink) Info() (*link.Info, error) { return f.info, f.err }
+func (f *fakeTCXLink) Close() error              { f.closed = true; return nil }
+
+func TestTCXInfoAlive(t *testing.T) {
+	assert.True(t, tcxInfoAlive(nil), "indeterminate metadata must not churn attachments")
+	assert.True(t, tcxInfoAlive(&link.TCXInfo{Ifindex: 42}), "non-zero ifindex is a live attachment")
+	assert.False(t, tcxInfoAlive(&link.TCXInfo{Ifindex: 0}), "ifindex 0 marks a defunct link (interface deleted)")
+}
+
+// A live recorded attachment must short-circuit the re-assert: no re-attach, the
+// stored value untouched.
+func TestCreateQdiscAndAttachSkipsLiveAttachment(t *testing.T) {
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
+
+	linkAttr := netlink.LinkAttrs{Name: "live", Index: 100}
+	seeded := &attachmentValue{
+		attachmentType: attachmentTypeTCX,
+		tcxIngressLink: &fakeTCXLink{info: &link.Info{}}, // no TCX metadata -> treated alive
+		tcxEgressLink:  &fakeTCXLink{info: &link.Info{}},
+	}
+
+	p := &packetParser{
+		l:             log.Logger().Named("test"),
+		attachmentMap: &sync.Map{},
+	}
+	p.attachmentMap.Store(ifaceToKey(linkAttr), seeded)
+
+	p.createQdiscAndAttach(linkAttr, Veth)
+
+	got, ok := p.attachmentMap.Load(ifaceToKey(linkAttr))
+	assert.True(t, ok)
+	assert.Same(t, seeded, got.(*attachmentValue), "live attachment must be left untouched")
+}
+
+// A stale record (links dead in the kernel: interface deleted with its index
+// reused, or programs detached externally) must be dropped and the interface
+// re-attached, so the level-triggered re-assert self-heals it.
+func TestCreateQdiscAndAttachReplacesStaleAttachment(t *testing.T) {
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mfilter := mocks.NewMockfilter(ctrl)
+	mfilter.EXPECT().Add(gomock.Any()).Return(nil).AnyTimes()
+	mq := mocks.NewMockqdisc(ctrl)
+	mq.EXPECT().Add(gomock.Any()).Return(nil).AnyTimes()
+	mrtnl := mocks.NewMocknltc(ctrl)
+	mrtnl.EXPECT().Qdisc().Return(nil).AnyTimes()
+	mrtnl.EXPECT().SetOption(nl.ExtendedAcknowledge, true).Return(nil).AnyTimes()
+	getQdisc = func(nltc) qdisc { return mq }
+	getFilter = func(nltc) filter { return mfilter }
+	tcOpen = func(*tc.Config) (nltc, error) { return mrtnl, nil }
+	getFD = func(_ *ebpf.Program) int { return 1 }
+
+	pObj := &packetparserObjects{} //nolint:typecheck // generated bpf2go type
+	pObj.EndpointIngressFilter = &ebpf.Program{}
+	pObj.EndpointEgressFilter = &ebpf.Program{}
+
+	linkAttr := netlink.LinkAttrs{Name: "stale", Index: 200}
+	deadIngress := &fakeTCXLink{err: errLinkDefunct}
+	deadEgress := &fakeTCXLink{err: errLinkDefunct}
+	seeded := &attachmentValue{
+		attachmentType: attachmentTypeTCX,
+		tcxIngressLink: deadIngress,
+		tcxEgressLink:  deadEgress,
+	}
+
+	p := &packetParser{
+		cfg:                 cfgPodLevelEnabled,
+		l:                   log.Logger().Named("test"),
+		objs:                pObj,
+		interfaceLockMap:    &sync.Map{},
+		endpointIngressInfo: &ebpf.ProgramInfo{Name: "ingress"},
+		endpointEgressInfo:  &ebpf.ProgramInfo{Name: "egress"},
+		attachmentMap:       &sync.Map{},
+	}
+	p.attachmentMap.Store(ifaceToKey(linkAttr), seeded)
+
+	p.createQdiscAndAttach(linkAttr, Veth)
+
+	got, ok := p.attachmentMap.Load(ifaceToKey(linkAttr))
+	assert.True(t, ok, "interface must be re-attached after the stale record is dropped")
+	assert.NotSame(t, seeded, got.(*attachmentValue), "stale record must be replaced by a fresh attachment")
+	assert.True(t, deadIngress.closed && deadEgress.closed, "stale link handles must be closed")
+}
+
+// A live legacy-TC attachment (a bpf filter still present on the interface's
+// ingress hook) must be left untouched on re-assert — no re-attach, no churn.
+func TestCreateQdiscAndAttachSkipsLiveTCAttachment(t *testing.T) {
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	const idx = 300
+	mfilter := mocks.NewMockfilter(ctrl)
+	mfilter.EXPECT().Get(gomock.Any()).Return([]tc.Object{
+		{Attribute: tc.Attribute{Kind: "bpf"}},
+	}, nil).Times(1)
+	getFilter = func(nltc) filter { return mfilter }
+
+	linkAttr := netlink.LinkAttrs{Name: "tc-live", Index: idx}
+	seeded := &attachmentValue{
+		attachmentType: attachmentTypeTC,
+		tc:             mocks.NewMocknltc(ctrl),
+		qdisc:          &tc.Object{Msg: tc.Msg{Ifindex: idx}},
+	}
+
+	p := &packetParser{
+		l:             log.Logger().Named("test"),
+		attachmentMap: &sync.Map{},
+	}
+	p.attachmentMap.Store(ifaceToKey(linkAttr), seeded)
+
+	p.createQdiscAndAttach(linkAttr, Veth)
+
+	got, ok := p.attachmentMap.Load(ifaceToKey(linkAttr))
+	assert.True(t, ok)
+	assert.Same(t, seeded, got.(*attachmentValue), "live TC attachment must be left untouched")
+}
+
+// A dead legacy-TC attachment (no bpf filter — interface deleted, possibly
+// index reused — or an unusable probe socket) must be re-attached and the stale
+// rtnetlink socket released — WITHOUT deleting the clsact qdisc, which on index
+// reuse may belong to the interface's new occupant (no mq.Delete expectation:
+// any Delete call fails the test).
+func TestCreateQdiscAndAttachReplacesDeadTCAttachment(t *testing.T) {
+	cases := []struct {
+		name  string
+		probe func(msg *tc.Msg) ([]tc.Object, error)
+	}{
+		{"no filters", func(*tc.Msg) ([]tc.Object, error) { return nil, nil }},
+		{"probe error", func(*tc.Msg) ([]tc.Object, error) { return nil, errTestRead }},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			const idx = 302
+			mq := mocks.NewMockqdisc(ctrl)
+			// Add is the re-attach. No Delete expectation: the dead path must not
+			// delete a qdisc it cannot prove is ours.
+			mq.EXPECT().Add(gomock.Any()).Return(nil).Times(1)
+			getQdisc = func(nltc) qdisc { return mq }
+
+			mfilter := mocks.NewMockfilter(ctrl)
+			mfilter.EXPECT().Get(gomock.Any()).DoAndReturn(tt.probe).Times(1)
+			mfilter.EXPECT().Add(gomock.Any()).Return(nil).Times(2)
+			getFilter = func(nltc) filter { return mfilter }
+			getFD = func(_ *ebpf.Program) int { return 1 }
+
+			newRtnl := mocks.NewMocknltc(ctrl)
+			newRtnl.EXPECT().SetOption(nl.ExtendedAcknowledge, true).Return(nil).Times(1)
+			tcOpen = func(*tc.Config) (nltc, error) { return newRtnl, nil }
+
+			// The stale attachment's socket must be closed when we drop it.
+			oldRtnl := mocks.NewMocknltc(ctrl)
+			oldRtnl.EXPECT().Close().Return(nil).Times(1)
+
+			pObj := &packetparserObjects{} //nolint:typecheck // generated bpf2go type
+			pObj.EndpointIngressFilter = &ebpf.Program{}
+			pObj.EndpointEgressFilter = &ebpf.Program{}
+
+			linkAttr := netlink.LinkAttrs{Name: "tc-dead", Index: idx}
+			seeded := &attachmentValue{
+				attachmentType: attachmentTypeTC,
+				tc:             oldRtnl,
+				qdisc:          &tc.Object{Msg: tc.Msg{Ifindex: idx}},
+			}
+
+			p := &packetParser{
+				cfg:                 cfgPodLevelEnabled,
+				l:                   log.Logger().Named("test"),
+				objs:                pObj,
+				interfaceLockMap:    &sync.Map{},
+				endpointIngressInfo: &ebpf.ProgramInfo{Name: "ingress"},
+				endpointEgressInfo:  &ebpf.ProgramInfo{Name: "egress"},
+				attachmentMap:       &sync.Map{},
+			}
+			p.attachmentMap.Store(ifaceToKey(linkAttr), seeded)
+
+			p.createQdiscAndAttach(linkAttr, Veth)
+
+			got, ok := p.attachmentMap.Load(ifaceToKey(linkAttr))
+			assert.True(t, ok, "interface must be re-attached after the dead record is dropped")
+			assert.NotSame(t, seeded, got.(*attachmentValue), "dead record must be replaced by a fresh attachment")
+		})
+	}
+}
+
+// A non-fatal SetOption failure must not poison the cleanup path: the attach
+// still succeeds and must NOT be torn down afterwards (no qdisc Delete, no
+// socket Close — either call fails the test via missing expectations).
+func TestAttachViaTCSurvivesSetOptionFailure(t *testing.T) {
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mq := mocks.NewMockqdisc(ctrl)
+	mq.EXPECT().Add(gomock.Any()).Return(nil).Times(1)
+	getQdisc = func(nltc) qdisc { return mq }
+
+	mfilter := mocks.NewMockfilter(ctrl)
+	mfilter.EXPECT().Add(gomock.Any()).Return(nil).Times(2)
+	getFilter = func(nltc) filter { return mfilter }
+	getFD = func(_ *ebpf.Program) int { return 1 }
+
+	mrtnl := mocks.NewMocknltc(ctrl)
+	mrtnl.EXPECT().SetOption(nl.ExtendedAcknowledge, true).Return(errTestRead).Times(1)
+	tcOpen = func(*tc.Config) (nltc, error) { return mrtnl, nil }
+
+	pObj := &packetparserObjects{} //nolint:typecheck // generated bpf2go type
+	pObj.EndpointIngressFilter = &ebpf.Program{}
+	pObj.EndpointEgressFilter = &ebpf.Program{}
+
+	p := &packetParser{
+		cfg:                 cfgPodLevelEnabled,
+		l:                   log.Logger().Named("test"),
+		objs:                pObj,
+		endpointIngressInfo: &ebpf.ProgramInfo{Name: "ingress"},
+		endpointEgressInfo:  &ebpf.ProgramInfo{Name: "egress"},
+		attachmentMap:       &sync.Map{},
+	}
+
+	linkAttr := netlink.LinkAttrs{Name: "tc-optfail", Index: 310}
+	p.attachViaTC(linkAttr, Veth)
+
+	_, ok := p.attachmentMap.Load(ifaceToKey(linkAttr))
+	assert.True(t, ok, "attach must survive a non-fatal SetOption failure")
+}
+
+// A failed attach must release the rtnetlink socket — the failure returns
+// shadow err, so a defer keyed on err instead of an explicit flag never runs,
+// leaking one fd per failed attach, once per refresh under the re-assert. The
+// clsact qdisc is undone only if we created it: a pre-existing one may belong
+// to another agent (no Delete expectation in that case — a Delete call fails
+// the test).
+func TestAttachViaTCReleasesSocketOnFailedAttach(t *testing.T) {
+	cases := []struct {
+		name        string
+		qdiscAddErr error
+		wantDelete  bool
+	}{
+		{"qdisc created by us", nil, true},
+		{"qdisc pre-existing (possibly another agent's)", os.ErrExist, false},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mq := mocks.NewMockqdisc(ctrl)
+			mq.EXPECT().Add(gomock.Any()).Return(tt.qdiscAddErr).Times(1)
+			if tt.wantDelete {
+				mq.EXPECT().Delete(gomock.Any()).Return(nil).Times(1) // undo our own qdisc
+			}
+			getQdisc = func(nltc) qdisc { return mq }
+
+			mfilter := mocks.NewMockfilter(ctrl)
+			mfilter.EXPECT().Add(gomock.Any()).Return(errTestRead).Times(1) // ingress add fails
+			getFilter = func(nltc) filter { return mfilter }
+			getFD = func(_ *ebpf.Program) int { return 1 }
+
+			mrtnl := mocks.NewMocknltc(ctrl)
+			mrtnl.EXPECT().SetOption(nl.ExtendedAcknowledge, true).Return(nil).Times(1)
+			mrtnl.EXPECT().Close().Return(nil).Times(1) // the fd must be released
+			tcOpen = func(*tc.Config) (nltc, error) { return mrtnl, nil }
+
+			pObj := &packetparserObjects{} //nolint:typecheck // generated bpf2go type
+			pObj.EndpointIngressFilter = &ebpf.Program{}
+			pObj.EndpointEgressFilter = &ebpf.Program{}
+
+			p := &packetParser{
+				cfg:                 cfgPodLevelEnabled,
+				l:                   log.Logger().Named("test"),
+				objs:                pObj,
+				endpointIngressInfo: &ebpf.ProgramInfo{Name: "ingress"},
+				endpointEgressInfo:  &ebpf.ProgramInfo{Name: "egress"},
+				attachmentMap:       &sync.Map{},
+			}
+
+			linkAttr := netlink.LinkAttrs{Name: "tc-addfail", Index: 311}
+			p.attachViaTC(linkAttr, Veth)
+
+			_, ok := p.attachmentMap.Load(ifaceToKey(linkAttr))
+			assert.False(t, ok, "failed attach must not be recorded")
+		})
+	}
+}
+
+// Stop must wait for a callback already past the stopping check: the cbMu
+// barrier holds teardown until the in-flight attach finishes, so its Store is
+// visible to cleanAll and the attachment is released rather than leaked.
+func TestStopWaitsForInFlightCallback(t *testing.T) {
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	mq := mocks.NewMockqdisc(ctrl)
+	mq.EXPECT().Add(gomock.Any()).DoAndReturn(func(*tc.Object) error {
+		close(entered)
+		<-release
+		return nil
+	}).Times(1)
+	mq.EXPECT().Delete(gomock.Any()).Return(nil).Times(1) // cleanAll releases the attachment
+	getQdisc = func(nltc) qdisc { return mq }
+
+	mfilter := mocks.NewMockfilter(ctrl)
+	mfilter.EXPECT().Add(gomock.Any()).Return(nil).Times(2)
+	getFilter = func(nltc) filter { return mfilter }
+	getFD = func(_ *ebpf.Program) int { return 1 }
+
+	mrtnl := mocks.NewMocknltc(ctrl)
+	mrtnl.EXPECT().SetOption(nl.ExtendedAcknowledge, true).Return(nil).Times(1)
+	mrtnl.EXPECT().Close().Return(nil).Times(1) // via cleanAll
+	tcOpen = func(*tc.Config) (nltc, error) { return mrtnl, nil }
+
+	pObj := &packetparserObjects{} //nolint:typecheck // generated bpf2go type
+	pObj.EndpointIngressFilter = &ebpf.Program{}
+	pObj.EndpointEgressFilter = &ebpf.Program{}
+
+	p := &packetParser{
+		cfg:                 cfgPodLevelEnabled,
+		l:                   log.Logger().Named("test"),
+		objs:                pObj,
+		interfaceLockMap:    &sync.Map{},
+		endpointIngressInfo: &ebpf.ProgramInfo{Name: "ingress"},
+		endpointEgressInfo:  &ebpf.ProgramInfo{Name: "egress"},
+		attachmentMap:       &sync.Map{},
+	}
+
+	// Deliver a create on a separate goroutine, as the pubsub drain goroutine would.
+	callbackDone := make(chan struct{})
+	go func() {
+		defer close(callbackDone)
+		p.endpointWatcherCallbackFn(endpoint.NewEndpointEvent(endpoint.EndpointCreated,
+			netlink.LinkAttrs{Name: "in-flight", Index: 330}))
+	}()
+	<-entered // callback is now mid-attach, inside cbMu
+	// The callback captured the program pointers before blocking; drop objs so
+	// Stop doesn't Close zero-value bpf2go objects (ordered by the entered chan).
+	p.objs = nil
+
+	stopDone := make(chan struct{})
+	go func() {
+		defer close(stopDone)
+		_ = p.Stop()
+	}()
+
+	select {
+	case <-stopDone:
+		t.Fatal("Stop returned while a callback was still in flight")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	close(release)
+	<-callbackDone
+	select {
+	case <-stopDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Stop did not complete after the in-flight callback finished")
+	}
+
+	// cleanAll must have observed the Store (mock expectations above) and reset the map.
+	count := 0
+	p.attachmentMap.Range(func(_, _ interface{}) bool { count++; return true })
+	assert.Zero(t, count, "the in-flight attachment must be cleaned by Stop, not leaked")
+}
+
+// After Stop, an endpoint delivery still in flight (pubsub does not join it)
+// must be a no-op. The parser's maps are nil here, so a broken guard panics.
+func TestStopQuiescesEndpointCallback(t *testing.T) {
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
+
+	p := &packetParser{l: log.Logger().Named("test")}
+	require.NoError(t, p.Stop())
+
+	ev := endpoint.NewEndpointEvent(endpoint.EndpointCreated, netlink.LinkAttrs{Name: "late", Index: 320})
+	assert.NotPanics(t, func() { p.endpointWatcherCallbackFn(ev) },
+		"a delivery after Stop must be dropped by the stopping guard")
+}
+
+// The delete callback must detach a TCX attachment via cleanTCX (closing both
+// links) and drop the map entry — the TCX counterpart of the TC clean path.
+func TestEndpointWatcherCallbackFn_EndpointDeletedTCX(t *testing.T) {
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
+
+	p := &packetParser{
+		cfg:              cfgPodLevelEnabled,
+		l:                log.Logger().Named("test"),
+		interfaceLockMap: &sync.Map{},
+		attachmentMap:    &sync.Map{},
+	}
+	linkAttr := netlink.LinkAttrs{Name: "tcx-del", Index: 301}
+	key := ifaceToKey(linkAttr)
+	ingress := &fakeTCXLink{info: &link.Info{}}
+	egress := &fakeTCXLink{info: &link.Info{}}
+	p.interfaceLockMap.Store(key, &sync.Mutex{})
+	p.attachmentMap.Store(key, &attachmentValue{
+		attachmentType: attachmentTypeTCX,
+		tcxIngressLink: ingress,
+		tcxEgressLink:  egress,
+	})
+
+	p.endpointWatcherCallbackFn(&endpoint.EndpointEvent{Type: endpoint.EndpointDeleted, Obj: linkAttr})
+
+	_, ok := p.attachmentMap.Load(key)
+	assert.False(t, ok, "attachmentMap entry should be deleted")
+	assert.True(t, ingress.closed && egress.closed, "TCX links should be closed on delete")
+	_, lockOK := p.interfaceLockMap.Load(key)
+	assert.False(t, lockOK, "interfaceLockMap entry should be deleted")
+}
+
 func TestReadData_Error(t *testing.T) {
-	log.SetupZapLogger(log.GetDefaultLogOpts())
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -376,7 +816,7 @@ func TestReadData_RingBufClosed(t *testing.T) {
 }
 
 func TestReadDataPodLevelEnabled(t *testing.T) {
-	log.SetupZapLogger(log.GetDefaultLogOpts())
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -434,7 +874,7 @@ func TestReadDataPodLevelEnabled(t *testing.T) {
 }
 
 func TestStartPodLevelDisabled(t *testing.T) {
-	log.SetupZapLogger(log.GetDefaultLogOpts())
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
 	p := &packetParser{
 		cfg: cfgPodLevelDisabled,
 		l:   log.Logger().Named("test"),
@@ -604,7 +1044,7 @@ func TestStartWithDataAggregationLevelHigh(t *testing.T) {
 }
 
 func TestInitPodLevelDisabled(t *testing.T) {
-	log.SetupZapLogger(log.GetDefaultLogOpts())
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
 	p := &packetParser{
 		cfg: cfgPodLevelDisabled,
 		l:   log.Logger().Named("test"),
@@ -617,7 +1057,7 @@ func TestPacketParseGenerate(t *testing.T) {
 	takeBackup()
 	defer restoreBackup()
 
-	log.SetupZapLogger(log.GetDefaultLogOpts())
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
 	// Get the directory of the current test file.
 	_, filename, _, ok := runtime.Caller(0)
 	if !ok {
@@ -696,7 +1136,7 @@ func TestCompile(t *testing.T) {
 	takeBackup()
 	defer restoreBackup()
 
-	log.SetupZapLogger(log.GetDefaultLogOpts())
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
 	p := &packetParser{
 		cfg: cfgPodLevelEnabled,
 		l:   log.Logger().Named(name),

--- a/pkg/plugin/packetparser/types_linux.go
+++ b/pkg/plugin/packetparser/types_linux.go
@@ -5,6 +5,7 @@ package packetparser
 
 import (
 	"sync"
+	"sync/atomic"
 
 	kcfg "github.com/microsoft/retina/pkg/config"
 
@@ -77,9 +78,7 @@ var (
 
 // attachmentKey uniquely identifies a network interface for BPF program attachment.
 type attachmentKey struct {
-	name         string
-	hardwareAddr string
-	netNs        int
+	index int
 }
 
 // attachmentType represents the method used to attach BPF programs.
@@ -97,8 +96,16 @@ type attachmentValue struct {
 	qdisc *tc.Object
 	// TCX-specific fields
 	attachmentType attachmentType
-	tcxIngressLink link.Link
-	tcxEgressLink  link.Link
+	tcxIngressLink tcxLink
+	tcxEgressLink  tcxLink
+}
+
+// tcxLink is the subset of link.Link the parser needs. Narrower than link.Link
+// (whose unexported marker method blocks fakes) so tests can inject dead links
+// into the liveness check.
+type tcxLink interface {
+	Info() (*link.Info, error)
+	Close() error
 }
 
 //go:generate go run go.uber.org/mock/mockgen@v0.4.0 -source=types_linux.go -destination=mocks/mock_types_linux.go -package=mocks -exclude_interfaces=perfReader
@@ -112,6 +119,7 @@ type qdisc interface {
 // tc filter interface
 type filter interface {
 	Add(info *tc.Object) error
+	Get(info *tc.Msg) ([]tc.Object, error)
 }
 
 // netlink tc interface
@@ -153,12 +161,21 @@ type packetParser struct {
 	recordsChannel      chan perfRecord
 	externalChannel     chan *v1.Event
 	tcxSupported        bool // Whether TCX is supported on this system
+	// stopping and cbMu let Stop reach quiescence with the endpoint callback:
+	// pubsub's Unsubscribe does not wait for a delivery already in flight, so Stop
+	// sets stopping (new deliveries become no-ops), unsubscribes, then locks cbMu
+	// to wait out an in-flight callback before tearing down maps/programs.
+	stopping atomic.Bool
+	cbMu     sync.Mutex
 }
 
+// ifaceToKey keys on the interface index (the target of the TCX/TC attach),
+// which is stable for the interface's lifetime, unlike NetNsID/HardwareAddr,
+// which change as a pod's veth is moved into its netns during init — keying on
+// those caused the same interface to be seen under multiple keys and re-attached
+// ("already attached").
 func ifaceToKey(iface netlink.LinkAttrs) attachmentKey {
 	return attachmentKey{
-		name:         iface.Name,
-		hardwareAddr: iface.HardwareAddr.String(),
-		netNs:        iface.NetNsID,
+		index: iface.Index,
 	}
 }

--- a/pkg/pubsub/mock_pubsubinterface.go
+++ b/pkg/pubsub/mock_pubsubinterface.go
@@ -56,6 +56,18 @@ func (mr *MockPubSubInterfaceMockRecorder) Publish(arg0, arg1 any) *gomock.Call 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Publish", reflect.TypeOf((*MockPubSubInterface)(nil).Publish), arg0, arg1)
 }
 
+// RegisterSource mocks base method.
+func (m *MockPubSubInterface) RegisterSource(arg0 PubSubTopic, arg1 func() []any) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "RegisterSource", arg0, arg1)
+}
+
+// RegisterSource indicates an expected call of RegisterSource.
+func (mr *MockPubSubInterfaceMockRecorder) RegisterSource(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterSource", reflect.TypeOf((*MockPubSubInterface)(nil).RegisterSource), arg0, arg1)
+}
+
 // Subscribe mocks base method.
 func (m *MockPubSubInterface) Subscribe(arg0 PubSubTopic, arg1 *CallBackFunc) string {
 	m.ctrl.T.Helper()

--- a/pkg/pubsub/pubsub.go
+++ b/pkg/pubsub/pubsub.go
@@ -11,103 +11,226 @@ import (
 	"go.uber.org/zap"
 )
 
+// backlogWarnThreshold is the per-subscriber backlog at which we warn that a
+// consumer is falling behind. The queue is unbounded (events are never dropped),
+// so a persistently slow consumer shows up as growing memory; the warning makes
+// that loud before it becomes a problem.
+const backlogWarnThreshold = 1024
+
 var (
 	p    *PubSub
 	once sync.Once
 )
 
-type PubSub struct {
-	sync.RWMutex
-	// l is the logger.
-	l *log.ZapLogger
-	// topicToCallback is a map of topic to a map of callback function
-	topicToCallback map[PubSubTopic]map[string]*CallBackFunc
+// subscriber buffers events in an unbounded, ordered queue drained by a single
+// goroutine. Ordering guarantees the initial snapshot is delivered before any
+// later event (e.g. a delete). It never drops and never blocks the publisher, so
+// one slow subscriber cannot stall the shared publisher. Mirrors client-go's
+// shared informer processorListener.
+//
+// Delivery does not begin until start() runs: Subscribe makes the subscriber
+// visible to publishers first (so live events buffer into pending), then start()
+// prepends the snapshot ahead of anything buffered and opens the gate. This lets
+// snapshot() run outside the PubSub lock — it must never be called under the lock
+// because a source may take other locks (or do I/O), which would risk deadlock
+// and stall every topic.
+type subscriber struct {
+	id    string
+	topic PubSubTopic
+	cb    *CallBackFunc
+	l     *log.ZapLogger
+
+	mu      sync.Mutex
+	cond    *sync.Cond
+	pending []interface{}
+	started bool
+	stopped bool
+	warned  bool
 }
 
-// New returns a new instance of PubSub.
+func newSubscriber(id string, topic PubSubTopic, cb *CallBackFunc, l *log.ZapLogger) *subscriber {
+	s := &subscriber{id: id, topic: topic, cb: cb, l: l}
+	s.cond = sync.NewCond(&s.mu)
+	go s.run()
+	return s
+}
+
+// enqueue appends an event. It never blocks the publisher and never drops.
+func (s *subscriber) enqueue(msg interface{}) {
+	s.mu.Lock()
+	if s.stopped {
+		s.mu.Unlock()
+		return
+	}
+	s.pending = append(s.pending, msg)
+	if len(s.pending) >= backlogWarnThreshold && !s.warned {
+		s.warned = true
+		s.l.Warn("pubsub subscriber backlog is large; consumer is falling behind",
+			zap.String("topic", string(s.topic)), zap.String("uuid", s.id), zap.Int("depth", len(s.pending)))
+	}
+	s.mu.Unlock()
+	s.cond.Signal()
+}
+
+// start prepends the initial snapshot ahead of any events buffered since the
+// subscriber became visible, then opens the delivery gate. Snapshot items are
+// therefore delivered before every later event, while events that raced in during
+// subscription still follow (idempotent consumers absorb any overlap).
+func (s *subscriber) start(snapshot []interface{}) {
+	s.mu.Lock()
+	if len(snapshot) > 0 {
+		s.pending = append(snapshot, s.pending...)
+	}
+	s.started = true
+	s.mu.Unlock()
+	s.cond.Signal()
+}
+
+func (s *subscriber) run() {
+	s.mu.Lock()
+	for {
+		for !s.stopped && (!s.started || len(s.pending) == 0) {
+			s.cond.Wait()
+		}
+		if s.stopped {
+			s.mu.Unlock()
+			return
+		}
+		msg := s.pending[0]
+		s.pending[0] = nil // release reference
+		s.pending = s.pending[1:]
+		if len(s.pending) == 0 {
+			s.pending = nil // release backing array once drained
+			s.warned = false
+		}
+		s.mu.Unlock()
+
+		// Callbacks are trusted code; a panic here is a bug and crashes the agent
+		// rather than being silently swallowed.
+		(*s.cb)(msg)
+
+		s.mu.Lock()
+	}
+}
+
+func (s *subscriber) stop() {
+	s.mu.Lock()
+	s.stopped = true
+	s.mu.Unlock()
+	s.cond.Broadcast()
+}
+
+type PubSub struct {
+	sync.RWMutex
+	l *log.ZapLogger
+	// subscribers maps a topic to its subscribers keyed by id.
+	subscribers map[PubSubTopic]map[string]*subscriber
+	// sources maps a topic to a snapshot provider replayed to new subscribers.
+	sources map[PubSubTopic]func() []interface{}
+}
+
+// New returns the singleton PubSub instance.
 func New() *PubSub {
 	once.Do(func() {
 		p = &PubSub{
-			l:               log.Logger().Named(string("PubSub")),
-			topicToCallback: make(map[PubSubTopic]map[string]*CallBackFunc),
+			l:           log.Logger().Named(string("PubSub")),
+			subscribers: make(map[PubSubTopic]map[string]*subscriber),
+			sources:     make(map[PubSubTopic]func() []interface{}),
 		}
 	})
 
 	return p
 }
 
-// Publish publishes the given message to the given topic,
-// and calls all the callback functions subscribed to the topic.
+// RegisterSource registers a snapshot provider for a topic. When a new
+// subscriber subscribes, the current snapshot is replayed to it before any
+// later event, so a subscriber that registers after events were published still
+// converges to the current state (informer-style list-then-watch). Callbacks
+// must be idempotent: a snapshot item may duplicate a concurrently published event.
+func (p *PubSub) RegisterSource(topic PubSubTopic, snapshot func() []interface{}) {
+	p.Lock()
+	defer p.Unlock()
+	p.sources[topic] = snapshot
+}
+
+// Publish enqueues msg to every current subscriber of the topic.
 func (p *PubSub) Publish(topic PubSubTopic, msg interface{}) {
 	p.RLock()
 	defer p.RUnlock()
 
-	// If there are no callbacks for the given topic, return nil.
-	if _, ok := p.topicToCallback[topic]; !ok {
-		p.l.Debug("no callbacks for topic", zap.String("topic", string(topic)))
+	subs := p.subscribers[topic]
+	if len(subs) == 0 {
+		// Not an error: with level-triggered re-assertion, publishing before a
+		// subscriber has joined is routine and self-heals on the next refresh.
+		p.l.Debug("no subscribers for topic", zap.String("topic", string(topic)))
 		return
 	}
 
-	// Run all callbacks in parallel using a wait group.
-	for uuid, callback := range p.topicToCallback[topic] {
-		callback := callback
-		p.l.Debug("running callback", zap.String("topic", string(topic)), zap.String("uuid", uuid))
-		go func() {
-			(*callback)(msg)
-		}()
+	for _, s := range subs {
+		s.enqueue(msg)
 	}
 }
 
-// Subscribe subscribes to the given topic and calls the given callback function
-// when a message is published to the topic, it returns a new uuid of the callback.
+// Subscribe registers callback for the topic and returns its id. If a source is
+// registered, its current snapshot is delivered to this subscriber before any
+// later event (informer-style list-then-watch); callbacks must be idempotent, as
+// a snapshot item may overlap a concurrently published event.
+//
+// The subscriber is made visible under the lock (so live events start buffering),
+// but snapshot() is invoked *after* releasing the lock and then prepended ahead of
+// anything buffered. This preserves ordering without holding the PubSub lock across
+// the source callback, which may take other locks or do I/O.
 func (p *PubSub) Subscribe(topic PubSubTopic, callback *CallBackFunc) string {
+	id := uuid.New().String()
+	s := newSubscriber(id, topic, callback, p.l)
+
 	p.Lock()
-	defer p.Unlock()
-
-	// If the topic does not exist, create it.
-	if _, ok := p.topicToCallback[topic]; !ok {
-		p.topicToCallback[topic] = make(map[string]*CallBackFunc)
+	if p.subscribers[topic] == nil {
+		p.subscribers[topic] = make(map[string]*subscriber)
 	}
+	p.subscribers[topic][id] = s
+	source := p.sources[topic]
+	p.Unlock()
 
-	// Generate a new uuid for the callback.
-	uuid := uuid.New().String()
-	// Add the callback to the topic.
-	p.topicToCallback[topic][uuid] = callback
-	p.l.Debug("subscribed to topic", zap.String("topic", string(topic)), zap.String("uuid", uuid))
+	// Captured outside the lock; ordering is preserved because s buffers any
+	// events published in this window and start() prepends the snapshot ahead of
+	// them. A snapshot taken here reflects all state up to this point, so nothing
+	// is missed: earlier events are in the snapshot, later ones are buffered.
+	var snapshot []interface{}
+	if source != nil {
+		snapshot = source()
+	}
+	s.start(snapshot)
 
-	return uuid
+	p.l.Debug("subscribed to topic", zap.String("topic", string(topic)), zap.String("uuid", id))
+	return id
 }
 
-// Unsubscribe unsubscribes from the given topic.
+// Unsubscribe removes the subscriber and stops its drain goroutine. It does
+// NOT wait for a delivery already in flight: the callback may still be running
+// (or run once more) after Unsubscribe returns. Callers that tear down state
+// the callback uses must synchronize in the callback itself (see packetparser's
+// stopping/cbMu handshake).
 func (p *PubSub) Unsubscribe(topic PubSubTopic, uuid string) error {
-	p.Lock()
-	defer p.Unlock()
-
 	if uuid == "" {
 		return fmt.Errorf("uuid cannot be empty")
 	}
 
-	// If the topic does not exist, return nil.
-	if _, ok := p.topicToCallback[topic]; !ok {
-		p.l.Debug("no callbacks for topic", zap.String("topic", string(topic)))
-		return nil
+	p.Lock()
+	var s *subscriber
+	if subs, ok := p.subscribers[topic]; ok {
+		if s = subs[uuid]; s != nil {
+			delete(subs, uuid)
+			if len(subs) == 0 {
+				delete(p.subscribers, topic)
+			}
+		}
 	}
+	p.Unlock()
 
-	// If the callback does not exist, return nil.
-	if _, ok := p.topicToCallback[topic][uuid]; !ok {
-		p.l.Debug("callback does not exist", zap.String("topic", string(topic)), zap.String("uuid", uuid))
-		return nil
+	if s != nil {
+		s.stop()
+		p.l.Debug("unsubscribed from topic", zap.String("topic", string(topic)), zap.String("uuid", uuid))
 	}
-
-	// Delete the callback from the topic.
-	delete(p.topicToCallback[topic], uuid)
-	p.l.Debug("unsubscribed from topic", zap.String("topic", string(topic)), zap.String("uuid", uuid))
-
-	// Delete the topic if there are no callbacks left.
-	if len(p.topicToCallback[topic]) == 0 {
-		delete(p.topicToCallback, topic)
-		p.l.Debug("deleted topic", zap.String("topic", string(topic)))
-	}
-
 	return nil
 }

--- a/pkg/pubsub/pubsub_test.go
+++ b/pkg/pubsub/pubsub_test.go
@@ -3,11 +3,13 @@
 package pubsub
 
 import (
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/microsoft/retina/pkg/log"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -15,19 +17,19 @@ const (
 )
 
 func TestNewPubSub(t *testing.T) {
-	log.SetupZapLogger(log.GetDefaultLogOpts())
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
 	p := New()
 	assert.NotNil(t, p)
 }
 
 func TestPublish(t *testing.T) {
-	log.SetupZapLogger(log.GetDefaultLogOpts())
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
 	p := New()
 	p.Publish("topic", "msg")
 }
 
 func TestSubscribe(t *testing.T) {
-	log.SetupZapLogger(log.GetDefaultLogOpts())
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
 	p := New()
 	cb := CallBackFunc(func(msg interface{}) {})
 
@@ -36,7 +38,7 @@ func TestSubscribe(t *testing.T) {
 }
 
 func TestUnsubscribe(t *testing.T) {
-	log.SetupZapLogger(log.GetDefaultLogOpts())
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
 	p := New()
 	cb := CallBackFunc(func(msg interface{}) {})
 
@@ -46,7 +48,7 @@ func TestUnsubscribe(t *testing.T) {
 }
 
 func TestMultipleSubscribe(t *testing.T) {
-	log.SetupZapLogger(log.GetDefaultLogOpts())
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
 
 	cb := CallBackFunc(func(msg interface{}) {})
 
@@ -58,7 +60,7 @@ func TestMultipleSubscribe(t *testing.T) {
 }
 
 func TestPubSub(t *testing.T) {
-	log.SetupZapLogger(log.GetDefaultLogOpts())
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
 	ps := New()
 
 	// Publisher 1 publishes a message to topic "topic1"
@@ -111,4 +113,214 @@ func TestPubSub(t *testing.T) {
 	}
 
 	time.Sleep(until)
+}
+
+func TestSubscribeReplaysSnapshot(t *testing.T) {
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
+	p := New()
+
+	// Source registered before anyone subscribes.
+	p.RegisterSource("snap-topic", func() []interface{} {
+		return []interface{}{"a", "b"}
+	})
+
+	var mu sync.Mutex
+	got := map[string]bool{}
+	cb := CallBackFunc(func(msg interface{}) {
+		mu.Lock()
+		got[msg.(string)] = true
+		mu.Unlock()
+	})
+
+	// Subscriber joins late; it must still receive the current snapshot.
+	id := p.Subscribe("snap-topic", &cb)
+	defer p.Unsubscribe("snap-topic", id) //nolint:errcheck // best-effort cleanup in test
+
+	assert.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return got["a"] && got["b"]
+	}, time.Second, 5*time.Millisecond, "expected snapshot replayed to a late subscriber")
+}
+
+func TestSnapshotDeliveredBeforeDeltas(t *testing.T) {
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
+	p := New()
+
+	p.RegisterSource("order-topic", func() []interface{} {
+		return []interface{}{"snapshot-add"}
+	})
+
+	var mu sync.Mutex
+	var order []string
+	cb := CallBackFunc(func(msg interface{}) {
+		mu.Lock()
+		order = append(order, msg.(string))
+		mu.Unlock()
+	})
+
+	id := p.Subscribe("order-topic", &cb)
+	defer p.Unsubscribe("order-topic", id) //nolint:errcheck // best-effort cleanup in test
+
+	// Subscribe enqueues the snapshot under the lock, so this later delta is
+	// ordered after it. FIFO delivery must yield snapshot-then-delta.
+	p.Publish("order-topic", "live-delete")
+
+	assert.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return len(order) == 2
+	}, time.Second, 5*time.Millisecond, "expected both events delivered")
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Equal(t, []string{"snapshot-add", "live-delete"}, order,
+		"snapshot must be delivered before later deltas (e.g. deletes)")
+}
+
+func TestSnapshotSourceRunsOutsideLock(t *testing.T) {
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
+	p := New()
+
+	// A snapshot source that re-enters PubSub (Publish takes the read lock).
+	// This deadlocks if snapshot() is invoked while the Subscribe path holds the
+	// write lock — the regression this guards against. Real sources instead take
+	// their own locks / do I/O, which is the same hazard (deadlock, or stalling
+	// every topic across a syscall).
+	p.RegisterSource("reentrant-topic", func() []interface{} {
+		p.Publish("sink-topic", "from-snapshot")
+		return []interface{}{"snap"}
+	})
+
+	sink := make(chan string, 1)
+	sinkCb := CallBackFunc(func(m interface{}) { sink <- m.(string) })
+	p.Subscribe("sink-topic", &sinkCb)
+
+	got := make(chan string, 1)
+	cb := CallBackFunc(func(m interface{}) { got <- m.(string) })
+
+	done := make(chan string, 1)
+	go func() { done <- p.Subscribe("reentrant-topic", &cb) }()
+
+	// Subscribe must return (no deadlock), the snapshot item must be delivered,
+	// and the event the source published must reach the sink subscriber.
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Subscribe hung; snapshot() appears to run under the PubSub lock")
+	}
+	select {
+	case v := <-got:
+		assert.Equal(t, "snap", v, "snapshot item should be delivered")
+	case <-time.After(time.Second):
+		t.Fatal("snapshot item not delivered")
+	}
+	select {
+	case v := <-sink:
+		assert.Equal(t, "from-snapshot", v, "event published from within snapshot should be delivered")
+	case <-time.After(time.Second):
+		t.Fatal("event published from within snapshot not delivered")
+	}
+}
+
+// TestDeltasDuringSubscribeFollowSnapshot pins the subscriber start-gate
+// invariant: an event published while the snapshot source is still running (the
+// subscriber is already visible to publishers, but delivery hasn't started) must
+// buffer and be delivered AFTER the snapshot, never before and never dropped.
+func TestDeltasDuringSubscribeFollowSnapshot(t *testing.T) {
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
+	p := New()
+
+	sourceEntered := make(chan struct{})
+	releaseSource := make(chan struct{})
+	p.RegisterSource("gate-topic", func() []interface{} {
+		close(sourceEntered)
+		<-releaseSource // hold the subscription open while the test publishes
+		return []interface{}{"snap"}
+	})
+
+	var mu sync.Mutex
+	var order []string
+	cb := CallBackFunc(func(m interface{}) {
+		mu.Lock()
+		order = append(order, m.(string))
+		mu.Unlock()
+	})
+
+	subscribed := make(chan string, 1)
+	go func() { subscribed <- p.Subscribe("gate-topic", &cb) }()
+
+	<-sourceEntered
+	// Subscriber is registered (visible) but gated; this must buffer, not drop.
+	p.Publish("gate-topic", "delta")
+	close(releaseSource)
+
+	id := <-subscribed
+	defer p.Unsubscribe("gate-topic", id) //nolint:errcheck // best-effort cleanup in test
+
+	assert.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return len(order) == 2
+	}, 2*time.Second, 5*time.Millisecond, "both the snapshot and the buffered delta must be delivered")
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Equal(t, []string{"snap", "delta"}, order,
+		"a delta buffered during subscription must follow the snapshot")
+}
+
+func TestUnsubscribeStopsDelivery(t *testing.T) {
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
+	p := New()
+
+	got := make(chan struct{}, 8)
+	cb := CallBackFunc(func(interface{}) { got <- struct{}{} })
+	id := p.Subscribe("unsub-topic", &cb)
+
+	p.Publish("unsub-topic", "m1")
+	select {
+	case <-got:
+	case <-time.After(time.Second):
+		t.Fatal("first event was not delivered")
+	}
+
+	require.NoError(t, p.Unsubscribe("unsub-topic", id))
+
+	// After unsubscribe the drain goroutine is stopped and the subscriber removed,
+	// so a later publish must not be delivered.
+	p.Publish("unsub-topic", "m2")
+	select {
+	case <-got:
+		t.Fatal("event delivered after unsubscribe")
+	case <-time.After(200 * time.Millisecond):
+	}
+}
+
+// RegisterSource keeps only the most recent source for a topic (last writer
+// wins) — the semantic the cache's explicit RegisterSnapshotSources wiring
+// depends on: whichever component registers last owns the topic's snapshot slot.
+func TestRegisterSourceLastWins(t *testing.T) {
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
+	p := New()
+	topic := PubSubTopic("last-wins-topic")
+	p.RegisterSource(topic, func() []interface{} { return []interface{}{"stale"} })
+	p.RegisterSource(topic, func() []interface{} { return []interface{}{"current"} })
+
+	got := make(chan interface{}, 2)
+	cb := CallBackFunc(func(msg interface{}) { got <- msg })
+	id := p.Subscribe(topic, &cb)
+	defer p.Unsubscribe(topic, id) //nolint:errcheck // best-effort cleanup in test
+
+	select {
+	case msg := <-got:
+		assert.Equal(t, "current", msg, "the last registered source must serve the snapshot")
+	case <-time.After(2 * time.Second):
+		t.Fatal("no snapshot delivered")
+	}
+	select {
+	case msg := <-got:
+		t.Fatalf("the overwritten source must not also fire, got: %v", msg)
+	case <-time.After(100 * time.Millisecond):
+	}
 }

--- a/pkg/pubsub/types.go
+++ b/pkg/pubsub/types.go
@@ -15,6 +15,8 @@ type PubSubInterface interface {
 	Subscribe(topic PubSubTopic, callback *CallBackFunc) string
 	// Unsubscribe unsubscribes from the given topic
 	Unsubscribe(topic PubSubTopic, uuid string) error
+	// RegisterSource registers a snapshot provider replayed to new subscribers
+	RegisterSource(topic PubSubTopic, snapshot func() []interface{})
 }
 
 type PubSubTopic string

--- a/pkg/watchers/apiserver/apiserver.go
+++ b/pkg/watchers/apiserver/apiserver.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"net/url"
 	"strings"
+	"sync"
 
 	"github.com/microsoft/retina/pkg/common"
 	cc "github.com/microsoft/retina/pkg/controllers/cache"
@@ -33,6 +34,7 @@ const (
 type ApiServerWatcher struct {
 	isRunning           bool
 	l                   *log.ZapLogger
+	mu                  sync.Mutex // guards current against concurrent snapshot reads
 	current             cache
 	new                 cache
 	apiServerHostName   string
@@ -102,9 +104,35 @@ func (a *ApiServerWatcher) Init(ctx context.Context) error {
 	}
 	a.apiServerHostName = hostName
 
+	// Register the snapshot source so a subscriber that joins after the watcher
+	// replays the current apiserver IP set immediately.
+	pubsub.New().RegisterSource(common.PubSubAPIServer, a.snapshot)
+
 	a.isRunning = true
 
 	return nil
+}
+
+// snapshot returns the current apiserver IPs as a single add event. Registered
+// as the pubsub source so late subscribers converge to the current set. It
+// applies the same IPv4 filter as Refresh's publishes: an IPv6 IP handed out
+// here would never be re-asserted nor deleted by the publish path, leaving the
+// subscriber with it forever.
+func (a *ApiServerWatcher) snapshot() []interface{} {
+	a.mu.Lock()
+	ips := make([]string, 0, len(a.current))
+	for k := range a.current {
+		if net.ParseIP(k).To4() == nil {
+			a.l.Warn("skipping non-IPv4 apiserver IP in snapshot", zap.String("ip", k))
+			continue
+		}
+		ips = append(ips, k)
+	}
+	a.mu.Unlock()
+	if len(ips) == 0 {
+		return nil
+	}
+	return []interface{}{cc.NewCacheEvent(cc.EventTypeAddAPIServerIPs, common.NewAPIServerObject(ips))}
 }
 
 // Stop stops the ApiServerWatcher.
@@ -124,42 +152,70 @@ func (a *ApiServerWatcher) Refresh(ctx context.Context) error {
 		return err
 	}
 
-	// Compare the new IPs with the old ones.
+	// created is only for operator-visible logging; adds are re-asserted from the
+	// full current set below. deleted drives removals.
 	created, deleted := a.diffCache()
-
-	createdIPs := []net.IP{}
-	deletedIPs := []net.IP{}
-
 	for _, v := range created {
-		a.l.Info("New Apiserver IPs:", zap.Any("ip", v))
-		ip := net.ParseIP(v.(string)).To4()
-		createdIPs = append(createdIPs, ip)
+		a.l.Info("New Apiserver IP", zap.Any("ip", v))
 	}
-
 	for _, v := range deleted {
-		a.l.Info("Deleted Apiserver IPs:", zap.Any("ip", v))
-		ip := net.ParseIP(v.(string)).To4()
-		deletedIPs = append(deletedIPs, ip)
+		a.l.Info("Deleted Apiserver IP", zap.Any("ip", v))
 	}
 
-	if len(createdIPs) > 0 {
-		a.publish(createdIPs, cc.EventTypeAddAPIServerIPs)
-		err := a.filterManager.AddIPs(createdIPs, "apiserver-watcher", fm.RequestMetadata{RuleID: "apiserver-watcher"})
-		if err != nil {
-			a.l.Error("Failed to add IPs to filter manager", zap.Error(err))
+	// currentIPs is the full live set (a.new); by construction it excludes
+	// anything in deleted (deleted = a.current - a.new). The filter map is
+	// IPv4-keyed, so skip anything To4 can't represent (e.g. IPv6 on dual-stack)
+	// — appending the nil would otherwise be re-asserted every refresh.
+	currentIPs := make([]net.IP, 0, len(a.new))
+	for k := range a.new {
+		if ip := net.ParseIP(k).To4(); ip != nil {
+			currentIPs = append(currentIPs, ip)
+		} else {
+			a.l.Warn("skipping non-IPv4 apiserver IP", zap.String("ip", k))
+		}
+	}
+	deletedIPs := make([]net.IP, 0, len(deleted))
+	for _, v := range deleted {
+		if ip := net.ParseIP(v.(string)).To4(); ip != nil {
+			deletedIPs = append(deletedIPs, ip)
+		} else {
+			a.l.Warn("skipping non-IPv4 apiserver IP", zap.String("ip", v.(string)))
 		}
 	}
 
+	// Commit current before publishing. snapshot() (served to new subscribers)
+	// reads a.current, so committing first ensures a subscriber joining during
+	// this refresh never sees a snapshot that still contains an IP whose delete we
+	// are about to publish — otherwise it would get the stale add via snapshot but
+	// miss the delete and keep the IP forever. currentIPs/deletedIPs are already
+	// captured above, so the publishes below are unaffected.
+	a.mu.Lock()
+	a.current = a.new.deepcopy()
+	a.mu.Unlock()
+	a.new = nil
+
+	// Publish deletes BEFORE the add re-assert. The cache keys all apiserver IPs
+	// under one endpoint (kubernetes-apiserver) and handles a delete by dropping
+	// the whole entry, so a delete published after the add would wipe the set
+	// just asserted and leave the cache without an apiserver endpoint until the
+	// next refresh. Delete-then-add converges immediately; the per-IP consumers
+	// are order-insensitive since the two sets are disjoint.
 	if len(deletedIPs) > 0 {
 		a.publish(deletedIPs, cc.EventTypeDeleteAPIServerIPs)
-		err := a.filterManager.DeleteIPs(deletedIPs, "apiserver-watcher", fm.RequestMetadata{RuleID: "apiserver-watcher"})
-		if err != nil {
+		if err := a.filterManager.DeleteIPs(deletedIPs, "apiserver-watcher", fm.RequestMetadata{RuleID: "apiserver-watcher"}); err != nil {
 			a.l.Error("Failed to delete IPs from filter manager", zap.Error(err))
 		}
 	}
 
-	a.current = a.new.deepcopy()
-	a.new = nil
+	// Re-assert all current IPs every refresh (level-triggered, idempotent):
+	// consumers self-heal a missed add regardless of subscribe timing, and this
+	// retries any filter-map add that previously failed.
+	if len(currentIPs) > 0 {
+		a.publish(currentIPs, cc.EventTypeAddAPIServerIPs)
+		if err := a.filterManager.AddIPs(currentIPs, "apiserver-watcher", fm.RequestMetadata{RuleID: "apiserver-watcher"}); err != nil {
+			a.l.Error("Failed to add IPs to filter manager", zap.Error(err))
+		}
+	}
 
 	return nil
 }

--- a/pkg/watchers/apiserver/apiserver_test.go
+++ b/pkg/watchers/apiserver/apiserver_test.go
@@ -9,12 +9,17 @@ import (
 	"errors"
 	"fmt"
 	"math/rand"
+	"net"
+	"sync"
 	"testing"
 	"time"
 
+	"github.com/microsoft/retina/pkg/common"
 	kcfg "github.com/microsoft/retina/pkg/config"
+	cc "github.com/microsoft/retina/pkg/controllers/cache"
 	"github.com/microsoft/retina/pkg/log"
 	filtermanagermocks "github.com/microsoft/retina/pkg/managers/filtermanager"
+	"github.com/microsoft/retina/pkg/pubsub"
 	"github.com/microsoft/retina/pkg/watchers/apiserver/mocks"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -31,7 +36,7 @@ import (
 var errDNS = errors.New("DNS error")
 
 func TestGetWatcher(t *testing.T) {
-	log.SetupZapLogger(log.GetDefaultLogOpts())
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
 
 	a := Watcher(kcfg.DefaultFilterMapMaxEntries)
 	assert.NotNil(t, a)
@@ -41,7 +46,7 @@ func TestGetWatcher(t *testing.T) {
 }
 
 func TestAPIServerWatcherStop(t *testing.T) {
-	log.SetupZapLogger(log.GetDefaultLogOpts())
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
 	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
 	defer cancel()
 	ctrl := gomock.NewController(t)
@@ -71,7 +76,7 @@ func TestAPIServerWatcherStop(t *testing.T) {
 }
 
 func TestRefresh(t *testing.T) {
-	log.SetupZapLogger(log.GetDefaultLogOpts())
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -100,8 +105,198 @@ func TestRefresh(t *testing.T) {
 	assert.NoError(t, a.Refresh(context.Background()), "Expected no error when refreshing the cache")
 }
 
+// TestRefreshSkipsNonIPv4 verifies IPv6 apiserver IPs (e.g. dual-stack) are
+// skipped rather than fed to the IPv4-keyed filter map as nils — which the
+// level-triggered re-assert would otherwise repeat every refresh.
+func TestRefreshSkipsNonIPv4(t *testing.T) {
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockedResolver := mocks.NewMockIHostResolver(ctrl)
+	mockedResolver.EXPECT().LookupHost(gomock.Any(), gomock.Any()).Return([]string{"10.9.9.9", "fd00::1"}, nil).AnyTimes()
+
+	var got []net.IP
+	mockedFilterManager := filtermanagermocks.NewMockIFilterManager(ctrl)
+	mockedFilterManager.EXPECT().AddIPs(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(ips []net.IP, _ filtermanagermocks.Requestor, _ filtermanagermocks.RequestMetadata) error {
+			got = ips
+			return nil
+		}).AnyTimes()
+	mockedFilterManager.EXPECT().DeleteIPs(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+
+	a := &ApiServerWatcher{
+		l:             log.Logger().Named("apiserver-watcher"),
+		hostResolver:  mockedResolver,
+		filterManager: mockedFilterManager,
+		client:        getMockKubeClient(),
+	}
+
+	require.NoError(t, a.Refresh(context.Background()))
+
+	// 3 IPv4s from the mock kube client + 1 from the resolver; fd00::1 skipped.
+	assert.Len(t, got, 4, "expected only the IPv4 addresses")
+	for _, ip := range got {
+		assert.NotNil(t, ip, "no nil entries may reach the filter manager")
+	}
+}
+
+// TestSnapshot verifies the pubsub snapshot source returns the current apiserver
+// IP set as a single add event (and nothing when empty), so a late subscriber
+// converges to the current state.
+func TestSnapshot(t *testing.T) {
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
+
+	a := &ApiServerWatcher{
+		l:       log.Logger().Named("apiserver-watcher"),
+		current: cache{},
+	}
+	assert.Nil(t, a.snapshot(), "empty current should yield no snapshot events")
+
+	a.current = cache{"10.0.0.1": struct{}{}, "10.0.0.2": struct{}{}, "fd00::1": struct{}{}}
+	snap := a.snapshot()
+	require.Len(t, snap, 1, "snapshot should be a single add event carrying all current IPs")
+	ev, ok := snap[0].(*cc.CacheEvent)
+	require.True(t, ok, "snapshot item should be a *cache.CacheEvent")
+	assert.Equal(t, cc.EventTypeAddAPIServerIPs, ev.Type, "snapshot event should be an apiserver-IP add")
+	obj, ok := ev.Obj.(*common.APIServerObject)
+	require.True(t, ok, "snapshot event payload should be an *common.APIServerObject")
+	got := make([]string, 0, len(obj.IPs()))
+	for _, ip := range obj.IPs() {
+		got = append(got, ip.String())
+	}
+	assert.ElementsMatch(t, []string{"10.0.0.1", "10.0.0.2"}, got,
+		"snapshot must carry the IPv4 set and skip IPv6, matching the publish path's filter")
+
+	// All-IPv6 current: nothing publishable, so no snapshot event at all.
+	a.current = cache{"fd00::2": struct{}{}}
+	assert.Nil(t, a.snapshot(), "an all-IPv6 set should yield no snapshot events")
+}
+
+// TestRefreshPublishesDeleteBeforeAdd pins the publish order on an IP change.
+// The cache keys every apiserver IP under one endpoint and handles a delete by
+// dropping the whole entry, so a delete published after the add re-assert would
+// wipe the set just asserted and leave the cache without an apiserver endpoint
+// until the next refresh.
+func TestRefreshPublishesDeleteBeforeAdd(t *testing.T) {
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockedResolver := mocks.NewMockIHostResolver(ctrl)
+	gomock.InOrder(
+		mockedResolver.EXPECT().LookupHost(gomock.Any(), gomock.Any()).Return([]string{"10.0.0.1", "10.0.0.2"}, nil).Times(1),
+		mockedResolver.EXPECT().LookupHost(gomock.Any(), gomock.Any()).Return([]string{"10.0.0.1"}, nil).Times(1),
+	)
+	mockedFilterManager := filtermanagermocks.NewMockIFilterManager(ctrl)
+	mockedFilterManager.EXPECT().AddIPs(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	mockedFilterManager.EXPECT().DeleteIPs(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+
+	a := &ApiServerWatcher{
+		l:             log.Logger().Named("apiserver-watcher"),
+		hostResolver:  mockedResolver,
+		filterManager: mockedFilterManager,
+		client:        getMockKubeClient(),
+		current:       cache{},
+	}
+
+	// Record the order of published event types on the apiserver topic.
+	var mu sync.Mutex
+	type published struct {
+		typ cc.EventType
+		ips []string
+	}
+	var events []published
+	fn := pubsub.CallBackFunc(func(msg interface{}) {
+		ev, ok := msg.(*cc.CacheEvent)
+		if !ok {
+			return
+		}
+		obj, ok := ev.Obj.(*common.APIServerObject)
+		if !ok || obj.EP == nil {
+			return
+		}
+		ips := []string{}
+		for _, ip := range obj.IPs() {
+			ips = append(ips, ip.String())
+		}
+		mu.Lock()
+		events = append(events, published{ev.Type, ips})
+		mu.Unlock()
+	})
+	ps := pubsub.New()
+	id := ps.Subscribe(common.PubSubAPIServer, &fn)
+	defer ps.Unsubscribe(common.PubSubAPIServer, id) //nolint:errcheck // best-effort cleanup in test
+
+	require.NoError(t, a.Refresh(context.Background()))
+	require.NoError(t, a.Refresh(context.Background())) // drops 10.0.0.2
+
+	assert.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		del := -1
+		for i, e := range events {
+			if e.typ == cc.EventTypeDeleteAPIServerIPs {
+				del = i
+				break
+			}
+		}
+		if del < 0 {
+			return false
+		}
+		assert.Equal(t, []string{"10.0.0.2"}, events[del].ips, "the delete must carry the dropped IP")
+		// The re-assert of the surviving set must come after the delete, so
+		// consumers that drop the whole entry on delete end converged.
+		for _, e := range events[del+1:] {
+			if e.typ == cc.EventTypeAddAPIServerIPs {
+				return true
+			}
+		}
+		return false
+	}, 2*time.Second, 10*time.Millisecond,
+		"expected the delete to be published before the add re-assert")
+}
+
+// TestSnapshotConcurrentWithRefresh hammers snapshot() while Refresh commits —
+// under -race this pins the mutex protecting a.current, the only thing that
+// makes serving snapshots to arbitrary subscriber goroutines safe.
+func TestSnapshotConcurrentWithRefresh(t *testing.T) {
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockedResolver := mocks.NewMockIHostResolver(ctrl)
+	mockedResolver.EXPECT().LookupHost(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(context.Context, string) ([]string, error) {
+			return []string{randomIP(), randomIP()}, nil
+		}).AnyTimes()
+	mockedFilterManager := filtermanagermocks.NewMockIFilterManager(ctrl)
+	mockedFilterManager.EXPECT().AddIPs(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	mockedFilterManager.EXPECT().DeleteIPs(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+
+	a := &ApiServerWatcher{
+		l:             log.Logger().Named("apiserver-watcher"),
+		hostResolver:  mockedResolver,
+		filterManager: mockedFilterManager,
+		client:        getMockKubeClient(),
+		current:       cache{},
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for range 200 {
+			a.snapshot()
+		}
+	}()
+	for range 10 {
+		require.NoError(t, a.Refresh(context.Background()))
+	}
+	<-done
+}
+
 func TestDiffCache(t *testing.T) {
-	log.SetupZapLogger(log.GetDefaultLogOpts())
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -128,7 +323,7 @@ func TestDiffCache(t *testing.T) {
 }
 
 func TestRefreshLookUpAlwaysFail(t *testing.T) {
-	log.SetupZapLogger(log.GetDefaultLogOpts())
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -150,7 +345,7 @@ func TestRefreshLookUpAlwaysFail(t *testing.T) {
 }
 
 func TestInitWithIncorrectURL(t *testing.T) {
-	log.SetupZapLogger(log.GetDefaultLogOpts())
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 

--- a/pkg/watchers/endpoint/endpoint.go
+++ b/pkg/watchers/endpoint/endpoint.go
@@ -5,6 +5,7 @@ package endpoint
 
 import (
 	"context"
+	"sync"
 
 	"github.com/microsoft/retina/pkg/common"
 	"github.com/microsoft/retina/pkg/log"
@@ -13,17 +14,34 @@ import (
 )
 
 type EndpointWatcher struct {
-	isRunning bool
-	l         *log.ZapLogger
-	current   cache
-	new       cache
-	p         pubsub.PubSubInterface
+	isRunning           bool
+	enableNetlinkEvents bool
+	l                   *log.ZapLogger
+	current             cache
+	new                 cache
+	p                   pubsub.PubSubInterface
+	mu                  sync.Mutex
+	// cancel tears down the goroutines Init started (netlink subscription and
+	// refresher). Derived from Init's ctx, so parent cancellation propagates and
+	// Stop works for standalone callers too — one signal, not a ctx/stop-channel pair.
+	cancel context.CancelFunc
+	// deletedIndexes holds interface indexes that netlink reported removed since
+	// the last refresh, guarded by delMu (the netlink reader writes it, Refresh
+	// drains it). It lets Refresh detect a delete+recreate that reused an index
+	// within one reconcile — which diffCache alone cannot see. Empty when netlink
+	// events are disabled or on Windows.
+	delMu          sync.Mutex
+	deletedIndexes map[int]struct{}
+	// hooks holds the watcher's OS-facing dependencies (netlink calls on linux),
+	// injectable per instance in tests. The type is defined per-OS. A zero value
+	// means production defaults (see osHooks on linux).
+	hooks hooks //nolint:unused // driven by osHooks on linux; windows has no netlink hooks
 }
 
 var e *EndpointWatcher
 
 // NewEndpointWatcher creates a new endpoint watcher.
-func Watcher() *EndpointWatcher {
+func Watcher(enableNetlinkEvents bool) *EndpointWatcher {
 	if e == nil {
 		e = &EndpointWatcher{
 			isRunning: false,
@@ -32,6 +50,7 @@ func Watcher() *EndpointWatcher {
 			current:   make(cache),
 		}
 	}
+	e.enableNetlinkEvents = enableNetlinkEvents
 
 	return e
 }
@@ -41,6 +60,12 @@ func (e *EndpointWatcher) Init(ctx context.Context) error {
 		e.l.Info("endpoint watcher is already running")
 		return nil
 	}
+	ctx, e.cancel = context.WithCancel(ctx)
+	// Register the snapshot source before subscribers join so a subscriber that
+	// joins after the watcher (e.g. packetparser) replays the current veth set
+	// immediately instead of waiting for the next refresh.
+	e.p.RegisterSource(common.PubSubEndpoints, e.snapshot)
+	e.subscribe(ctx)
 	e.isRunning = true
 	return nil
 }
@@ -50,31 +75,100 @@ func (e *EndpointWatcher) Stop(ctx context.Context) error {
 		e.l.Info("endpoint watcher is not running")
 		return nil
 	}
+	if e.cancel != nil {
+		e.cancel()
+		e.cancel = nil
+	}
 	e.isRunning = false
 	return nil
 }
 
+// recordDeletedIndex notes an interface index netlink reported removed. Called
+// from the netlink reader goroutine; drained by Refresh.
+func (e *EndpointWatcher) recordDeletedIndex(index int) {
+	e.delMu.Lock()
+	if e.deletedIndexes == nil {
+		e.deletedIndexes = make(map[int]struct{})
+	}
+	e.deletedIndexes[index] = struct{}{}
+	e.delMu.Unlock()
+}
+
+// drainDeletedIndexes returns and clears the indexes netlink reported removed
+// since the last call.
+func (e *EndpointWatcher) drainDeletedIndexes() map[int]struct{} {
+	e.delMu.Lock()
+	d := e.deletedIndexes
+	e.deletedIndexes = nil
+	e.delMu.Unlock()
+	return d
+}
+
 func (e *EndpointWatcher) Refresh(ctx context.Context) error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	// Drain netlink-reported deletes BEFORE listing. A delete that lands after
+	// the list would pair with the stale pre-delete sample and misread as a
+	// reuse (index present in both old and new), publishing a spurious
+	// delete+create for an interface that is simply gone. Drained-first, a
+	// record inserted after this point stays queued for the next refresh —
+	// which the same delete event also triggers — so nothing is lost.
+	drained := e.drainDeletedIndexes()
+
 	// initNewCache is OS specific.
 	// Based on GOOS, will be implemented by either endpoint_linux, or
 	// endpoint_windows.
 	err := e.initNewCache()
 	if err != nil {
+		// Re-queue the drained records so a failed list doesn't lose them; a
+		// genuine reuse they describe would otherwise become undetectable.
+		for idx := range drained {
+			e.recordDeletedIndex(idx)
+		}
 		return err
 	}
 
-	// Compare the new veths with the old ones.
+	// Handle interface-index reuse before diffing. If netlink reported index N
+	// deleted and the re-list now shows a *different* interface at N (a new veth
+	// reused the freed index before we sampled), a plain diff sees N in both the
+	// old and new cache and emits nothing — leaving the old occupant attached and
+	// the new one unattached. Publish a delete for the old occupant now (so
+	// consumers detach) and drop it from current, so diffCache/the re-assert below
+	// treat the new occupant as freshly created and (re)attach it. Ordering holds:
+	// this delete is published before the create re-assert, and delivery is FIFO
+	// per subscriber. Pure deletes (N gone, not reused) are left to diffCache.
+	for idx := range drained {
+		k := key{index: idx}
+		old, inCurrent := e.current[k]
+		if _, inNew := e.new[k]; !inCurrent || !inNew {
+			continue
+		}
+		e.l.Info("interface index reused; detaching old interface before re-attaching",
+			zap.String("old", describeEndpoint(old)), zap.Int("index", idx))
+		e.p.Publish(common.PubSubEndpoints, NewEndpointEvent(EndpointDeleted, old))
+		delete(e.current, k)
+	}
+
 	created, deleted := e.diffCache()
 
-	// Publish the new veths.
+	// Log interfaces appearing/disappearing (the diff only, not the full
+	// re-assert below) at info, mirroring the apiserver watcher's IP logging.
 	for _, v := range created {
-		e.l.Debug("Endpoint created", zap.Any("veth", v))
+		e.l.Info("New endpoint interface", zap.String("endpoint", describeEndpoint(v)))
+	}
+	for _, v := range deleted {
+		e.l.Info("Deleted endpoint interface", zap.String("endpoint", describeEndpoint(v)))
+	}
+
+	// Re-assert every current veth on each refresh (level-triggered): consumers
+	// attach idempotently, so a create event dropped before a subscriber was
+	// ready self-heals on the next refresh.
+	for _, v := range e.new {
 		e.p.Publish(common.PubSubEndpoints, NewEndpointEvent(EndpointCreated, v))
 	}
 
 	// Publish the deleted veths.
 	for _, v := range deleted {
-		e.l.Debug("Endpoint deleted", zap.Any("veth", v))
 		e.p.Publish(common.PubSubEndpoints, NewEndpointEvent(EndpointDeleted, v))
 	}
 
@@ -83,6 +177,24 @@ func (e *EndpointWatcher) Refresh(ctx context.Context) error {
 	e.new = nil
 
 	return nil
+}
+
+// snapshot returns the current veth set as EndpointCreated events. Registered
+// as the pubsub source so a subscriber that joins after startup (e.g.
+// packetparser) receives the current set immediately instead of waiting for
+// the next refresh. It serves e.current — the same state deletes are diffed
+// against — under the same lock Refresh commits it: a subscriber can never
+// receive a create whose delete the diff would not later publish. (Listing the
+// kernel here instead could hand a subscriber a veth that dies before the next
+// Refresh commits it to current, orphaning the create forever.)
+func (e *EndpointWatcher) snapshot() []interface{} {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	events := make([]interface{}, 0, len(e.current))
+	for _, v := range e.current {
+		events = append(events, NewEndpointEvent(EndpointCreated, v))
+	}
+	return events
 }
 
 // Function to differentiate between two caches.

--- a/pkg/watchers/endpoint/endpoint_churn_ebpf_test.go
+++ b/pkg/watchers/endpoint/endpoint_churn_ebpf_test.go
@@ -1,0 +1,154 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+//go:build ebpf && linux
+
+// Real-kernel test for the pod-restart attach path. Creates and deletes veths
+// and verifies the netlink fast path emits EndpointCreated/EndpointDeleted with
+// low (sub-poll-interval) latency. Requires NET_ADMIN; run via `make test-ebpf`
+// (sudo) or in a privileged linux container:
+//
+//	docker run --privileged -v "$PWD":/src -w /src golang:1.26 \
+//	  go test -tags=ebpf -run VethChurn ./pkg/watchers/endpoint/
+package endpoint
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/microsoft/retina/pkg/common"
+	"github.com/microsoft/retina/pkg/log"
+	"github.com/microsoft/retina/pkg/pubsub"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/vishvananda/netlink"
+)
+
+const (
+	churnRounds = 20
+	namePool    = 5
+	vethPrefix  = "rtnchurn"
+	peerPrefix  = "rtnpeer" // deliberately not matching vethPrefix so peers are ignored
+)
+
+// cleanupChurnVeths removes any leftover test veths (deleting one end removes the pair).
+func cleanupChurnVeths(t *testing.T) {
+	t.Helper()
+	links, err := netlink.LinkList()
+	if err != nil {
+		return
+	}
+	for _, l := range links {
+		n := l.Attrs().Name
+		if strings.HasPrefix(n, vethPrefix) || strings.HasPrefix(n, peerPrefix) {
+			_ = netlink.LinkDel(l)
+		}
+	}
+}
+
+// TestVethChurnLatency simulates pod restarts (delete/recreate of the same veth
+// identity) and asserts every create yields an EndpointCreated quickly and every
+// delete yields an EndpointDeleted.
+func TestVethChurnLatency(t *testing.T) {
+	log.SetupZapLogger(log.GetDefaultLogOpts())
+	cleanupChurnVeths(t)
+	t.Cleanup(func() { cleanupChurnVeths(t) })
+
+	ps := pubsub.New()
+
+	var mu sync.Mutex
+	createdAt := map[string]time.Time{}
+	deletedAt := map[string]time.Time{}
+	cb := pubsub.CallBackFunc(func(msg interface{}) {
+		ev, ok := msg.(*EndpointEvent)
+		if !ok {
+			return
+		}
+		attrs, ok := ev.Obj.(netlink.LinkAttrs)
+		if !ok || !strings.HasPrefix(attrs.Name, vethPrefix) {
+			return
+		}
+		mu.Lock()
+		defer mu.Unlock()
+		switch ev.Type {
+		case EndpointCreated:
+			if _, seen := createdAt[attrs.Name]; !seen {
+				createdAt[attrs.Name] = time.Now()
+			}
+		case EndpointDeleted:
+			if _, seen := deletedAt[attrs.Name]; !seen {
+				deletedAt[attrs.Name] = time.Now()
+			}
+		}
+	})
+	id := ps.Subscribe(common.PubSubEndpoints, &cb)
+	defer ps.Unsubscribe(common.PubSubEndpoints, id) //nolint:errcheck
+
+	v := &EndpointWatcher{
+		enableNetlinkEvents: true,
+		l:                   log.Logger().Named("churn-watcher"),
+		p:                   ps,
+		current:             make(cache),
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	v.subscribe(ctx)
+
+	var latencies []time.Duration
+	for i := 0; i < churnRounds; i++ {
+		// Reuse a small name pool so each round is a delete+recreate of the same
+		// pod-like identity — the exact path a pod restart exercises.
+		name := fmt.Sprintf("%s%d", vethPrefix, i%namePool)
+		peer := fmt.Sprintf("%s%d", peerPrefix, i%namePool)
+
+		la := netlink.NewLinkAttrs()
+		la.Name = name
+		veth := &netlink.Veth{LinkAttrs: la, PeerName: peer}
+
+		start := time.Now()
+		require.NoError(t, netlink.LinkAdd(veth), "LinkAdd %s (round %d)", name, i)
+
+		require.Eventually(t, func() bool {
+			mu.Lock()
+			defer mu.Unlock()
+			_, ok := createdAt[name]
+			return ok
+		}, 5*time.Second, 2*time.Millisecond, "EndpointCreated for %s (round %d)", name, i)
+
+		mu.Lock()
+		latencies = append(latencies, createdAt[name].Sub(start))
+		mu.Unlock()
+
+		require.NoError(t, netlink.LinkDel(veth), "LinkDel %s (round %d)", name, i)
+
+		require.Eventually(t, func() bool {
+			mu.Lock()
+			defer mu.Unlock()
+			_, ok := deletedAt[name]
+			return ok
+		}, 5*time.Second, 2*time.Millisecond, "EndpointDeleted for %s (round %d)", name, i)
+
+		// Reset so the next reuse of this name is observed afresh.
+		mu.Lock()
+		delete(createdAt, name)
+		delete(deletedAt, name)
+		mu.Unlock()
+	}
+
+	var maxLat, total time.Duration
+	for _, l := range latencies {
+		total += l
+		if l > maxLat {
+			maxLat = l
+		}
+	}
+	avg := total / time.Duration(len(latencies))
+	t.Logf("veth create->EndpointCreated latency: avg=%v max=%v over %d rounds", avg, maxLat, len(latencies))
+
+	// The whole point: attach latency is event-driven, not bound to the poll interval.
+	assert.Less(t, maxLat, 2*time.Second, "attach event latency should be far below any refresh interval")
+}

--- a/pkg/watchers/endpoint/endpoint_linux.go
+++ b/pkg/watchers/endpoint/endpoint_linux.go
@@ -4,13 +4,181 @@
 package endpoint
 
 import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
 	"github.com/vishvananda/netlink"
+	"go.uber.org/zap"
+	"golang.org/x/sys/unix"
 )
 
-var showLink = netlink.LinkList
+// listVethsMaxAttempts bounds how many times listVeths retries a dump that the
+// kernel reported interrupted (NLM_F_DUMP_INTR). A dump races a concurrent link
+// change; retrying gets a consistent snapshot instead of reconciling against a
+// partial one (which would look like spurious deletes).
+const listVethsMaxAttempts = 5
+
+const (
+	linkUpdateChanSize = 64
+	// defaultResubscribeBackoff is the delay before re-establishing a dead
+	// netlink subscription.
+	defaultResubscribeBackoff = 2 * time.Second
+)
+
+// hooks are the watcher's OS-facing dependencies, injectable per instance in
+// tests. Instance fields rather than package vars: watcher goroutines outlive a
+// test body, so swapping-and-restoring globals races their reads.
+type hooks struct {
+	listLinks          func() ([]netlink.Link, error)
+	linkSubscribe      func(chan<- netlink.LinkUpdate, <-chan struct{}, netlink.LinkSubscribeOptions) error
+	resubscribeBackoff time.Duration
+}
+
+// osHooks returns the instance hooks with production defaults filled in for any
+// zero fields, so a watcher constructed without hooks behaves like production.
+func (e *EndpointWatcher) osHooks() hooks {
+	h := e.hooks
+	if h.listLinks == nil {
+		h.listLinks = netlink.LinkList
+	}
+	if h.linkSubscribe == nil {
+		h.linkSubscribe = netlink.LinkSubscribeWithOptions
+	}
+	if h.resubscribeBackoff == 0 {
+		h.resubscribeBackoff = defaultResubscribeBackoff
+	}
+	return h
+}
+
+// subscribe triggers an immediate Refresh whenever a veth appears or disappears,
+// removing the up-to-refresh-interval attach delay. Periodic Refresh remains the backstop.
+func (e *EndpointWatcher) subscribe(ctx context.Context) {
+	if !e.enableNetlinkEvents {
+		return
+	}
+	trigger := make(chan struct{}, 1)
+	go e.runNetlink(ctx, trigger)   // keeps a subscription alive, records events
+	go e.runRefresher(ctx, trigger) // reconciles when triggered
+}
+
+// runNetlink keeps a netlink link subscription alive. The netlink library ends its
+// receive goroutine on any receive error, which closes the updates channel. We
+// detect that and resubscribe after a backoff,
+// and reconcile on every (re)connect so state cannot drift while the fast path was
+// down. Periodic Refresh remains the ultimate backstop, so a transient outage only
+// adds latency, never a permanent loss of the fast path.
+//
+// An RTM_DELLINK dropped while the subscription is down is never recorded, so an
+// index reuse spanning the outage is invisible to Refresh's reuse detection. That
+// is compensated downstream: the level-triggered re-assert redelivers every
+// current interface each refresh, and packetparser verifies recorded attachments
+// are still live in the kernel before skipping (see createQdiscAndAttach) — TCX
+// via the link's ifindex, legacy TC via a targeted per-ifindex filter presence
+// query — so a stale attachment self-heals within one refresh (for legacy TC's
+// accepted false-alive gaps, see tcAttachmentAlive).
+func (e *EndpointWatcher) runNetlink(ctx context.Context, trigger chan<- struct{}) {
+	h := e.osHooks()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+
+		// Per-subscription done channel: closing it lets the netlink library close
+		// its socket, so resubscribing doesn't leak the previous one.
+		subDone := make(chan struct{})
+		updates := make(chan netlink.LinkUpdate, linkUpdateChanSize)
+		err := h.linkSubscribe(updates, subDone, netlink.LinkSubscribeOptions{
+			ListExisting: true,
+			ErrorCallback: func(err error) {
+				// The initial ListExisting dump can race a link change; our reconcile
+				// re-lists (with its own retry), so this is benign.
+				if errors.Is(err, netlink.ErrDumpInterrupted) {
+					e.l.Debug("netlink initial dump interrupted; reconcile will re-list", zap.Error(err))
+					return
+				}
+				e.l.Warn("netlink link subscription error", zap.Error(err))
+			},
+		})
+		if err != nil {
+			e.l.Error("netlink subscribe failed; retrying", zap.Error(err))
+		} else {
+			e.l.Info("netlink-driven endpoint refresh enabled")
+			// ListExisting replays every current link as an event, so (re)connecting
+			// drives a reconcile on its own — catching anything that changed while the
+			// subscription was down without an explicit kick here.
+			e.readLinkUpdates(ctx, updates, trigger)
+		}
+		close(subDone) // release this subscription's socket
+
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(h.resubscribeBackoff):
+		}
+	}
+}
+
+// readLinkUpdates drains a subscription until it closes (netlink ended it) or the
+// watcher stops, returning so runNetlink can resubscribe.
+func (e *EndpointWatcher) readLinkUpdates(ctx context.Context, updates <-chan netlink.LinkUpdate, trigger chan<- struct{}) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case u, ok := <-updates:
+			if !ok {
+				e.l.Warn("netlink subscription closed; resubscribing")
+				return
+			}
+			if u.Link == nil || u.Type() != "veth" {
+				continue
+			}
+			// RTM_DELLINK carries the veth type, so record the removed index here.
+			// Refresh uses it to detect a delete+recreate that reused the index
+			// within a single reconcile (see Refresh).
+			if u.Header.Type == unix.RTM_DELLINK {
+				e.recordDeletedIndex(u.Attrs().Index)
+			}
+			e.signal(trigger)
+		}
+	}
+}
+
+func (e *EndpointWatcher) runRefresher(ctx context.Context, trigger <-chan struct{}) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-trigger:
+			if err := e.Refresh(ctx); err != nil {
+				e.l.Error("netlink-driven refresh failed", zap.Error(err))
+			}
+		}
+	}
+}
+
+// signal requests a reconcile without blocking; a pending request coalesces.
+func (e *EndpointWatcher) signal(trigger chan<- struct{}) {
+	select {
+	case trigger <- struct{}{}:
+	default:
+	}
+}
+
+// describeEndpoint renders a veth for logging as "name (index N)".
+func describeEndpoint(v interface{}) string {
+	if a, ok := v.(netlink.LinkAttrs); ok {
+		return fmt.Sprintf("%s (index %d)", a.Name, a.Index)
+	}
+	return "unknown"
+}
 
 func (e *EndpointWatcher) initNewCache() error {
-	veths, err := listVeths()
+	veths, err := e.listVeths()
 	if err != nil {
 		return err
 	}
@@ -19,9 +187,7 @@ func (e *EndpointWatcher) initNewCache() error {
 	e.new = make(cache)
 	for _, veth := range veths {
 		k := key{
-			name:         veth.Attrs().Name,
-			hardwareAddr: veth.Attrs().HardwareAddr.String(),
-			netNsID:      veth.Attrs().NetNsID,
+			index: veth.Attrs().Index,
 		}
 
 		e.new[k] = *veth.Attrs()
@@ -30,12 +196,19 @@ func (e *EndpointWatcher) initNewCache() error {
 	return nil
 }
 
-// Helper functions.
-
-// Get all the veth interfaces.
-// Similar to ip link show type veth
-func listVeths() ([]netlink.Link, error) {
-	links, err := showLink()
+// listVeths returns all veth interfaces, like `ip link show type veth`.
+func (e *EndpointWatcher) listVeths() ([]netlink.Link, error) {
+	listLinks := e.osHooks().listLinks
+	var links []netlink.Link
+	var err error
+	for range listVethsMaxAttempts {
+		links, err = listLinks()
+		// On a clean dump (or a non-retryable error) stop; on an interrupted dump
+		// the results may be incomplete, so discard and retry for a consistent one.
+		if !errors.Is(err, netlink.ErrDumpInterrupted) {
+			break
+		}
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/watchers/endpoint/endpoint_linux_test.go
+++ b/pkg/watchers/endpoint/endpoint_linux_test.go
@@ -7,33 +7,41 @@ package endpoint
 import (
 	"context"
 	"errors"
-	"net"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
+	"github.com/microsoft/retina/pkg/common"
 	"github.com/microsoft/retina/pkg/log"
 	"github.com/microsoft/retina/pkg/pubsub"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
 )
 
-func TestGetWatcher(t *testing.T) {
-	log.SetupZapLogger(log.GetDefaultLogOpts())
+var errTest = errors.New("test error")
 
-	v := Watcher()
+func TestGetWatcher(t *testing.T) {
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
+
+	v := Watcher(false)
 	assert.NotNil(t, v)
 
-	v_again := Watcher()
-	assert.Equal(t, v, v_again, "Expected the same veth watcher instance")
+	vAgain := Watcher(false)
+	assert.Equal(t, v, vAgain, "Expected the same veth watcher instance")
 }
 
 func TestEndpointWatcherStart(t *testing.T) {
-	log.SetupZapLogger(log.GetDefaultLogOpts())
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
 	c := context.Background()
 
 	// When veth is already running.
 	v := &EndpointWatcher{
 		isRunning: true,
 		l:         log.Logger().Named("veth-watcher"),
+		p:         pubsub.New(),
 	}
 	err := v.Init(c)
 	assert.NoError(t, err, "Expected no error when starting a running veth watcher")
@@ -60,13 +68,14 @@ func TestEndpointWatcherStart(t *testing.T) {
 }
 
 func TestEndpointWatcherStop(t *testing.T) {
-	log.SetupZapLogger(log.GetDefaultLogOpts())
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
 	c := context.Background()
 
 	// When veth is already stopped.
 	v := &EndpointWatcher{
 		isRunning: false,
 		l:         log.Logger().Named("veth-watcher"),
+		p:         pubsub.New(),
 	}
 	err := v.Stop(c)
 	assert.NoError(t, err, "Expected no error when stopping a stopped veth watcher")
@@ -83,7 +92,7 @@ func TestEndpointWatcherStop(t *testing.T) {
 }
 
 func TestRun(t *testing.T) {
-	showLink = func() ([]netlink.Link, error) {
+	v := &EndpointWatcher{hooks: hooks{listLinks: func() ([]netlink.Link, error) {
 		return []netlink.Link{
 			&netlink.Veth{
 				LinkAttrs: netlink.LinkAttrs{
@@ -96,9 +105,9 @@ func TestRun(t *testing.T) {
 				},
 			},
 		}, nil
-	}
+	}}}
 
-	links, err := listVeths()
+	links, err := v.listVeths()
 	assert.NoError(t, err, "Expected no error when listing veths")
 	assert.Equal(t, 1, len(links), "Expected to find 1 veth")
 	assert.Equal(t, "veth0", links[0].Attrs().Name, "Expected to find veth0")
@@ -107,18 +116,14 @@ func TestRun(t *testing.T) {
 func TestDiffCache(t *testing.T) {
 	old := cache{
 		key{
-			name:         "veth0",
-			hardwareAddr: "00:00:00:00:00:00",
-			netNsID:      0,
+			index: 0,
 		}: netlink.LinkAttrs{
 			Name: "veth0",
 		},
 	}
 	new := cache{
 		key{
-			name:         "veth1",
-			hardwareAddr: "00:00:00:00:00:FF",
-			netNsID:      1,
+			index: 1,
 		}: netlink.LinkAttrs{
 			Name: "veth1",
 		},
@@ -132,29 +137,21 @@ func TestDiffCache(t *testing.T) {
 }
 
 func TestRefreshAndCallback(t *testing.T) {
-	log.SetupZapLogger(log.GetDefaultLogOpts())
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
 	c := context.Background()
 
-	showLink = func() ([]netlink.Link, error) {
+	listLinks := func() ([]netlink.Link, error) {
 		return []netlink.Link{
 			&netlink.Veth{
 				LinkAttrs: netlink.LinkAttrs{
-					Name: "veth0",
-					HardwareAddr: func() net.HardwareAddr {
-						mac, _ := net.ParseMAC("00:00:00:00:00:00")
-						return mac
-					}(),
-					NetNsID: 0,
+					Name:  "veth0",
+					Index: 10,
 				},
 			},
 			&netlink.Veth{
 				LinkAttrs: netlink.LinkAttrs{
-					Name: "veth1",
-					HardwareAddr: func() net.HardwareAddr {
-						mac, _ := net.ParseMAC("00:00:00:00:00:01")
-						return mac
-					}(),
-					NetNsID: 1,
+					Name:  "veth1",
+					Index: 11,
 				},
 			},
 		}, nil
@@ -162,9 +159,7 @@ func TestRefreshAndCallback(t *testing.T) {
 
 	cache := make(cache)
 	cache[key{
-		name:         "veth2",
-		hardwareAddr: "00:00:00:00:00:02",
-		netNsID:      2,
+		index: 12,
 	}] = &netlink.Veth{
 		LinkAttrs: netlink.LinkAttrs{
 			Name: "veth2",
@@ -176,6 +171,7 @@ func TestRefreshAndCallback(t *testing.T) {
 		current:   cache,
 		l:         log.Logger().Named("veth-watcher"),
 		p:         pubsub.New(),
+		hooks:     hooks{listLinks: listLinks},
 	}
 
 	// When cache is empty.
@@ -186,43 +182,456 @@ func TestRefreshAndCallback(t *testing.T) {
 	assert.NoError(t, err, "Expected no error when refreshing veth cache")
 	assert.Equal(t, 2, len(v.current), "Expected to find 2 veths")
 	assert.Equal(t, "veth0", v.current[key{
-		name:         "veth0",
-		hardwareAddr: "00:00:00:00:00:00",
-		netNsID:      0,
+		index: 10,
 	}].(netlink.LinkAttrs).Name, "Expected to find veth0")
 	assert.Equal(t, "veth1", v.current[key{
-		name:         "veth1",
-		hardwareAddr: "00:00:00:00:00:01",
-		netNsID:      1,
+		index: 11,
 	}].(netlink.LinkAttrs).Name, "Expected to find veth1")
 }
 
 func TestRefreshError(t *testing.T) {
-	log.SetupZapLogger(log.GetDefaultLogOpts())
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
 	c := context.Background()
-
-	showLink = func() ([]netlink.Link, error) {
-		return nil, errors.New("error")
-	}
 
 	v := &EndpointWatcher{
 		isRunning: true,
 		current:   make(cache),
 		l:         log.Logger().Named("veth-watcher"),
 		p:         pubsub.New(),
+		hooks: hooks{listLinks: func() ([]netlink.Link, error) {
+			return nil, errTest
+		}},
 	}
 
 	err := v.Refresh(c)
 	assert.Error(t, err, "Expected an error when refreshing veth cache")
 }
 
-func TestListVethsError(t *testing.T) {
-	log.SetupZapLogger(log.GetDefaultLogOpts())
+func TestRefreshReassertsAllCurrent(t *testing.T) {
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
 
-	showLink = func() ([]netlink.Link, error) {
-		return nil, errors.New("error")
+	ps := pubsub.New()
+	var created atomic.Int32
+	fn := pubsub.CallBackFunc(func(msg interface{}) {
+		if ev, ok := msg.(*EndpointEvent); ok && ev.Type == EndpointCreated {
+			created.Add(1)
+		}
+	})
+	id := ps.Subscribe(common.PubSubEndpoints, &fn)
+	defer ps.Unsubscribe(common.PubSubEndpoints, id) //nolint:errcheck // best-effort cleanup in test
+
+	v := &EndpointWatcher{
+		current: make(cache),
+		l:       log.Logger().Named("veth-watcher"),
+		p:       ps,
+		hooks: hooks{listLinks: func() ([]netlink.Link, error) {
+			return []netlink.Link{
+				&netlink.Veth{LinkAttrs: netlink.LinkAttrs{Name: "veth0"}},
+			}, nil
+		}},
 	}
 
-	_, err := listVeths()
+	c := context.Background()
+	assert.NoError(t, v.Refresh(c))
+	assert.NoError(t, v.Refresh(c))
+
+	// Level-triggered: the veth is re-published on every refresh. Publish runs
+	// callbacks asynchronously, so poll. Use >= 2 because a snapshot source may
+	// also be registered on the shared pubsub singleton and add replays.
+	assert.Eventually(t, func() bool { return created.Load() >= 2 }, time.Second, 10*time.Millisecond,
+		"expected the veth to be re-asserted on each refresh")
+}
+
+func TestNetlinkTriggersRefresh(t *testing.T) {
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
+
+	capturedCh := make(chan chan<- netlink.LinkUpdate, 1)
+	v := &EndpointWatcher{
+		enableNetlinkEvents: true,
+		l:                   log.Logger().Named("veth-watcher"),
+		p:                   pubsub.New(),
+		current:             make(cache),
+		hooks: hooks{
+			listLinks: func() ([]netlink.Link, error) {
+				return []netlink.Link{
+					&netlink.Veth{LinkAttrs: netlink.LinkAttrs{Name: "veth-new"}},
+				}, nil
+			},
+			linkSubscribe: func(ch chan<- netlink.LinkUpdate, _ <-chan struct{}, _ netlink.LinkSubscribeOptions) error {
+				capturedCh <- ch
+				return nil
+			},
+		},
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	v.subscribe(ctx)
+
+	ch := <-capturedCh
+	ch <- netlink.LinkUpdate{Link: &netlink.Veth{LinkAttrs: netlink.LinkAttrs{Name: "veth-new"}}}
+
+	assert.Eventually(t, func() bool {
+		v.mu.Lock()
+		defer v.mu.Unlock()
+		return len(v.current) == 1
+	}, time.Second, 10*time.Millisecond, "expected netlink event to trigger a refresh")
+}
+
+// endpointEvent is a captured (type, name) pair for a given interface index.
+type endpointEvent struct {
+	typ  EventType
+	name string
+}
+
+// captureEndpointEvents subscribes and records events for a single interface index.
+func captureEndpointEvents(t *testing.T, ps pubsub.PubSubInterface, index int) (*sync.Mutex, *[]endpointEvent) {
+	t.Helper()
+	var mu sync.Mutex
+	events := &[]endpointEvent{}
+	fn := pubsub.CallBackFunc(func(msg interface{}) {
+		e, ok := msg.(*EndpointEvent)
+		if !ok {
+			return
+		}
+		attrs, ok := e.Obj.(netlink.LinkAttrs)
+		if !ok || attrs.Index != index {
+			return
+		}
+		mu.Lock()
+		*events = append(*events, endpointEvent{e.Type, attrs.Name})
+		mu.Unlock()
+	})
+	id := ps.Subscribe(common.PubSubEndpoints, &fn)
+	t.Cleanup(func() { ps.Unsubscribe(common.PubSubEndpoints, id) }) //nolint:errcheck // best-effort cleanup in test
+	return &mu, events
+}
+
+// A veth can be deleted and a new veth can reuse its interface index before the
+// watcher re-lists. diffCache alone sees the index in both snapshots and emits
+// nothing, so the old occupant stays attached and the new one never attaches.
+// The netlink delete record must force a detach of the old occupant followed by
+// an attach of the new one. This drives it end-to-end through the netlink reader.
+func TestNetlinkDeleteTriggersReattachOnIndexReuse(t *testing.T) {
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
+
+	const idx = 4242
+	capturedCh := make(chan chan<- netlink.LinkUpdate, 1)
+	ps := pubsub.New()
+	mu, events := captureEndpointEvents(t, ps, idx)
+
+	v := &EndpointWatcher{
+		enableNetlinkEvents: true,
+		l:                   log.Logger().Named("veth-watcher"),
+		p:                   ps,
+		current:             cache{key{index: idx}: netlink.LinkAttrs{Name: "vethA", Index: idx}},
+		hooks: hooks{
+			listLinks: func() ([]netlink.Link, error) {
+				return []netlink.Link{
+					&netlink.Veth{LinkAttrs: netlink.LinkAttrs{Name: "vethB", Index: idx}},
+				}, nil
+			},
+			linkSubscribe: func(ch chan<- netlink.LinkUpdate, _ <-chan struct{}, _ netlink.LinkSubscribeOptions) error {
+				capturedCh <- ch
+				return nil
+			},
+		},
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	v.subscribe(ctx)
+
+	ch := <-capturedCh
+	ch <- netlink.LinkUpdate{
+		Header: unix.NlMsghdr{Type: unix.RTM_DELLINK},
+		Link:   &netlink.Veth{LinkAttrs: netlink.LinkAttrs{Name: "vethA", Index: idx}},
+	}
+
+	assert.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		del := -1
+		for i, e := range *events {
+			if e.typ == EndpointDeleted && e.name == "vethA" {
+				del = i
+				break
+			}
+		}
+		if del < 0 {
+			return false
+		}
+		for _, e := range (*events)[del+1:] {
+			if e.typ == EndpointCreated && e.name == "vethB" {
+				return true
+			}
+		}
+		return false
+	}, 2*time.Second, 10*time.Millisecond,
+		"expected netlink delete of a reused index to detach vethA then attach vethB")
+}
+
+// A drained delete record must survive a failed re-list: Refresh re-queues it,
+// so a reuse that spans the transient failure is still detected on the next
+// pass (delete of the old occupant before the create of the new one).
+func TestRefreshRequeuesDrainedDeletesOnListFailure(t *testing.T) {
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
+
+	const idx = 6001
+	ps := pubsub.New()
+	mu, events := captureEndpointEvents(t, ps, idx)
+
+	calls := 0
+	v := &EndpointWatcher{
+		l:       log.Logger().Named("veth-watcher"),
+		p:       ps,
+		current: cache{key{index: idx}: netlink.LinkAttrs{Name: "vethA", Index: idx}},
+		hooks: hooks{listLinks: func() ([]netlink.Link, error) {
+			calls++
+			if calls == 1 {
+				return nil, errTest
+			}
+			return []netlink.Link{
+				&netlink.Veth{LinkAttrs: netlink.LinkAttrs{Name: "vethB", Index: idx}},
+			}, nil
+		}},
+	}
+	v.recordDeletedIndex(idx)
+
+	require.Error(t, v.Refresh(context.Background()), "first refresh surfaces the list failure")
+	require.NoError(t, v.Refresh(context.Background()))
+
+	assert.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		del := -1
+		for i, e := range *events {
+			if e.typ == EndpointDeleted && e.name == "vethA" {
+				del = i
+				break
+			}
+		}
+		if del < 0 {
+			return false
+		}
+		for _, e := range (*events)[del+1:] {
+			if e.typ == EndpointCreated && e.name == "vethB" {
+				return true
+			}
+		}
+		return false
+	}, 2*time.Second, 10*time.Millisecond,
+		"a reuse spanning a failed list must still detach vethA then attach vethB")
+}
+
+// A netlink-reported delete for an index that was NOT reused is handled by
+// diffCache normally; the reuse path must skip it so the delete isn't published
+// twice.
+func TestRefreshPlainDeleteEmitsSingleDelete(t *testing.T) {
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
+
+	const idx = 5555
+	ps := pubsub.New()
+	var deletes atomic.Int32
+	fn := pubsub.CallBackFunc(func(msg interface{}) {
+		e, ok := msg.(*EndpointEvent)
+		if !ok {
+			return
+		}
+		if attrs, ok := e.Obj.(netlink.LinkAttrs); ok && attrs.Index == idx && e.Type == EndpointDeleted {
+			deletes.Add(1)
+		}
+	})
+	id := ps.Subscribe(common.PubSubEndpoints, &fn)
+	defer ps.Unsubscribe(common.PubSubEndpoints, id) //nolint:errcheck // best-effort cleanup in test
+
+	v := &EndpointWatcher{
+		current: cache{key{index: idx}: netlink.LinkAttrs{Name: "vethGone", Index: idx}},
+		l:       log.Logger().Named("veth-watcher"),
+		p:       ps,
+		// index gone, not reused
+		hooks: hooks{listLinks: func() ([]netlink.Link, error) { return nil, nil }},
+	}
+	v.recordDeletedIndex(idx)
+	assert.NoError(t, v.Refresh(context.Background()))
+	assert.NoError(t, v.Refresh(context.Background()))
+
+	assert.Eventually(t, func() bool { return deletes.Load() >= 1 }, time.Second, 10*time.Millisecond,
+		"expected the deleted index to be published as deleted")
+	// Let any erroneous duplicate arrive before asserting it was published once.
+	time.Sleep(100 * time.Millisecond)
+	assert.Equal(t, int32(1), deletes.Load(), "delete must be published exactly once (no double-emit)")
+}
+
+// TestSnapshotReturnsCurrentVeths verifies the pubsub snapshot source serves the
+// committed current set as EndpointCreated events, so a subscriber joining after
+// startup converges to the same state deletes are diffed against.
+func TestSnapshotReturnsCurrentVeths(t *testing.T) {
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
+
+	v := &EndpointWatcher{
+		l: log.Logger().Named("veth-watcher"),
+		current: cache{
+			key{index: 7}: netlink.LinkAttrs{Name: "veth0", Index: 7},
+			key{index: 8}: netlink.LinkAttrs{Name: "veth1", Index: 8},
+		},
+	}
+
+	snap := v.snapshot()
+	assert.Len(t, snap, 2, "snapshot should include every current veth")
+	seen := map[int]bool{}
+	for _, item := range snap {
+		ev, ok := item.(*EndpointEvent)
+		assert.True(t, ok, "snapshot item should be an *EndpointEvent")
+		assert.Equal(t, EndpointCreated, ev.Type, "snapshot events should be creates")
+		attrs, ok := ev.Obj.(netlink.LinkAttrs)
+		assert.True(t, ok, "snapshot event payload should be netlink.LinkAttrs")
+		seen[attrs.Index] = true
+	}
+	assert.True(t, seen[7] && seen[8], "snapshot should carry both veth indexes")
+}
+
+// A snapshot must never hand a subscriber a veth the diff state doesn't know
+// about: a create served from a fresh kernel list, for a veth that dies before
+// the next Refresh commits it to current, would have no matching delete ever —
+// the subscriber holds an attachment forever. Serving from current makes this
+// impossible: the veth is either committed (its later delete will be diffed and
+// published) or absent from the snapshot.
+func TestSnapshotServesCommittedStateNotKernelList(t *testing.T) {
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
+
+	kernelHas := []netlink.Link{
+		&netlink.Veth{LinkAttrs: netlink.LinkAttrs{Name: "veth-uncommitted", Index: 9}},
+	}
+	v := &EndpointWatcher{
+		l:       log.Logger().Named("veth-watcher"),
+		current: make(cache), // nothing committed yet
+		hooks:   hooks{listLinks: func() ([]netlink.Link, error) { return kernelHas, nil }},
+	}
+
+	assert.Empty(t, v.snapshot(),
+		"snapshot must not surface veths the diff state has not committed")
+}
+
+// The netlink library ends its subscription (closing the updates channel) on any
+// receive error, including a socket-buffer overflow. The watcher must resubscribe
+// rather than silently lose the fast path for the rest of the process's life.
+func TestNetlinkResubscribesAfterClose(t *testing.T) {
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
+
+	var calls atomic.Int32
+	chs := make(chan chan<- netlink.LinkUpdate, 64)
+	v := &EndpointWatcher{
+		enableNetlinkEvents: true,
+		l:                   log.Logger().Named("veth-watcher"),
+		p:                   pubsub.New(),
+		current:             make(cache),
+		hooks: hooks{
+			resubscribeBackoff: 10 * time.Millisecond,
+			listLinks:          func() ([]netlink.Link, error) { return nil, nil },
+			linkSubscribe: func(ch chan<- netlink.LinkUpdate, _ <-chan struct{}, _ netlink.LinkSubscribeOptions) error {
+				calls.Add(1)
+				select {
+				case chs <- ch:
+				default:
+				}
+				return nil
+			},
+		},
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	v.subscribe(ctx)
+
+	// First subscription is established, then dies (channel closed).
+	ch1 := <-chs
+	close(ch1)
+
+	assert.Eventually(t, func() bool { return calls.Load() >= 2 }, 2*time.Second, 10*time.Millisecond,
+		"expected the watcher to resubscribe after the subscription closed")
+}
+
+// Stop must tear down the netlink goroutines Init started, without racing them:
+// Init derives an internal context and Stop cancels it (there is no separate
+// stop channel to race on). Observable via the per-subscription done channel,
+// which runNetlink closes on exit.
+func TestStopTearsDownNetlinkGoroutines(t *testing.T) {
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
+
+	subDones := make(chan (<-chan struct{}), 1)
+	v := &EndpointWatcher{
+		enableNetlinkEvents: true,
+		l:                   log.Logger().Named("veth-watcher"),
+		p:                   pubsub.New(),
+		current:             make(cache),
+		hooks: hooks{
+			resubscribeBackoff: 10 * time.Millisecond,
+			listLinks:          func() ([]netlink.Link, error) { return nil, nil },
+			linkSubscribe: func(_ chan<- netlink.LinkUpdate, done <-chan struct{}, _ netlink.LinkSubscribeOptions) error {
+				select {
+				case subDones <- done:
+				default:
+				}
+				return nil
+			},
+		},
+	}
+
+	require.NoError(t, v.Init(context.Background()))
+	done := <-subDones
+	require.NoError(t, v.Stop(context.Background()))
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("netlink goroutine did not exit after Stop")
+	}
+}
+
+// An interrupted dump (NLM_F_DUMP_INTR) may return incomplete results; listVeths
+// must retry for a consistent snapshot rather than surfacing partial data (which
+// would look like spurious interface deletes to the reconcile).
+func TestListVethsRetriesOnDumpInterrupted(t *testing.T) {
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
+
+	calls := 0
+	good := []netlink.Link{&netlink.Veth{LinkAttrs: netlink.LinkAttrs{Name: "veth0", Index: 3}}}
+	v := &EndpointWatcher{hooks: hooks{listLinks: func() ([]netlink.Link, error) {
+		calls++
+		if calls < 3 {
+			return nil, netlink.ErrDumpInterrupted
+		}
+		return good, nil
+	}}}
+
+	veths, err := v.listVeths()
+	require.NoError(t, err, "an interrupted dump should be retried, not surfaced")
+	assert.Equal(t, 3, calls, "listVeths should retry until it gets a consistent dump")
+	assert.Len(t, veths, 1, "should return the veths from the consistent dump")
+}
+
+// A persistently interrupted dump eventually gives up (bounded retries) and
+// surfaces the error, so Refresh skips the cycle rather than acting on bad data.
+func TestListVethsGivesUpAfterMaxDumpInterrupts(t *testing.T) {
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
+
+	calls := 0
+	v := &EndpointWatcher{hooks: hooks{listLinks: func() ([]netlink.Link, error) {
+		calls++
+		return nil, netlink.ErrDumpInterrupted
+	}}}
+
+	_, err := v.listVeths()
+	require.ErrorIs(t, err, netlink.ErrDumpInterrupted)
+	assert.Equal(t, listVethsMaxAttempts, calls, "should retry up to the bound then give up")
+}
+
+func TestListVethsError(t *testing.T) {
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
+
+	v := &EndpointWatcher{hooks: hooks{listLinks: func() ([]netlink.Link, error) {
+		return nil, errTest
+	}}}
+
+	_, err := v.listVeths()
 	assert.Error(t, err, "Expected an error when listing veths")
 }

--- a/pkg/watchers/endpoint/endpoint_windows.go
+++ b/pkg/watchers/endpoint/endpoint_windows.go
@@ -6,13 +6,16 @@
 package endpoint
 
 import (
-	"github.com/Microsoft/hcsshim/hcn"
+	"context"
 )
+
+// hooks has no OS-facing dependencies to inject on Windows.
+type hooks struct{} //nolint:unused // satisfies the shared EndpointWatcher.hooks field; no netlink on windows
+
+func (e *EndpointWatcher) subscribe(_ context.Context) {}
+
+func describeEndpoint(_ interface{}) string { return "" }
 
 func (e *EndpointWatcher) initNewCache() error {
 	return nil
-}
-
-func listVeths() ([]hcn.HostComputeEndpoint, error) {
-	return nil, nil
 }

--- a/pkg/watchers/endpoint/types.go
+++ b/pkg/watchers/endpoint/types.go
@@ -9,11 +9,11 @@ const (
 )
 
 type key struct {
-	name         string
-	hardwareAddr string
-	// Network namespace for linux.
-	// Compartment ID for windows.
-	netNsID int
+	// index is the interface index (linux) / compartment id (windows). It is the
+	// identifier the TCX/TC hook attaches with and is stable for the interface's
+	// lifetime, unlike name and NetNsID which change as a pod's veth is renamed
+	// and moved into its netns during init.
+	index int
 }
 
 type cache map[key]interface{}

--- a/test/managers/filtermanager/main.go
+++ b/test/managers/filtermanager/main.go
@@ -39,8 +39,8 @@ func main() {
 	ctx := context.Background()
 
 	// watcher manager
-	wm := watchermanager.NewWatcherManager(kcfg.DefaultFilterMapMaxEntries)
-	wm.Watchers = []watchermanager.IWatcher{endpoint.Watcher(), apiserver.Watcher(kcfg.DefaultFilterMapMaxEntries)}
+	wm := watchermanager.NewWatcherManager(kcfg.DefaultFilterMapMaxEntries, false, 0)
+	wm.Watchers = []watchermanager.IWatcher{endpoint.Watcher(false), apiserver.Watcher(kcfg.DefaultFilterMapMaxEntries)}
 
 	err := wm.Start(ctx)
 	if err != nil {

--- a/test/plugin/packetparser/main_linux.go
+++ b/test/plugin/packetparser/main_linux.go
@@ -33,8 +33,8 @@ func main() {
 	ctxTimeout, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 
 	// watcher manager
-	wm := watchermanager.NewWatcherManager(kcfg.DefaultFilterMapMaxEntries)
-	wm.Watchers = []watchermanager.IWatcher{endpoint.Watcher()}
+	wm := watchermanager.NewWatcherManager(kcfg.DefaultFilterMapMaxEntries, false, 0)
+	wm.Watchers = []watchermanager.IWatcher{endpoint.Watcher(false)}
 
 	err := wm.Start(ctxTimeout)
 	if err != nil {

--- a/test/watchers/apiserver/main.go
+++ b/test/watchers/apiserver/main.go
@@ -36,7 +36,7 @@ func main() {
 		}
 	}()
 	// watcher manager
-	wm := watchermanager.NewWatcherManager(kcfg.DefaultFilterMapMaxEntries)
+	wm := watchermanager.NewWatcherManager(kcfg.DefaultFilterMapMaxEntries, false, 0)
 	wm.Watchers = []watchermanager.IWatcher{apiserver.Watcher(kcfg.DefaultFilterMapMaxEntries)}
 
 	// apiserver watcher.

--- a/test/watchers/veth/main.go
+++ b/test/watchers/veth/main.go
@@ -24,8 +24,8 @@ func main() {
 	ctx := context.Background()
 
 	// watcher manager
-	wm := watchermanager.NewWatcherManager(kcfg.DefaultFilterMapMaxEntries)
-	wm.Watchers = []watchermanager.IWatcher{endpoint.Watcher()}
+	wm := watchermanager.NewWatcherManager(kcfg.DefaultFilterMapMaxEntries, false, 0)
+	wm.Watchers = []watchermanager.IWatcher{endpoint.Watcher(false)}
 
 	err := wm.Start(ctx)
 	if err != nil {


### PR DESCRIPTION
# Description

Right now attachment of TC/TCX hooks to new veths is polling based.  As such, there is a period after new pod creation where connection direction is lost since the initial SYN/ACK handshake isn't captured.

This changes API server and endpoint watchers to use snapshot-on-subscribe semantics to solve a few problems:

1) No ordering dependency between watcher startup and pubsub event subscription, upon subscribe consumers receive a full snapshot of all veths and then receive event-driven updates.
2) Since endpoint update events are now immediate there is no delay prior to attaching the TC/TCX hooks and thus less chance of not observing the SYN/ACK on initial connections to the pod.

In order to accomplish this, we now send the full set of endpoints and API server IPs to all consumers and rely on idempotency in the consumers to maintain correctness.  This is also self-healing, making sure that any missed events are properly reconciled during the next poll-based interval.

The polling interval is also now configurable as it is the backstop for correctness.

<details>
<summary>AI-generated summary</summary>

What

Makes the endpoint attach path event-driven and self-healing. On pod churn, eBPF programs attach within milliseconds of the veth appearing instead of waiting for the periodic watcher refresh. Gated by enableEndpointNetlinkEvents (default false); watcherRefreshInterval (default 30s) is now configurable and remains the backstop.

How

- pubsub: per-subscriber ordered FIFO delivery + snapshot-on-subscribe (RegisterSource), replacing the previous unordered goroutine-per-callback dispatch. Snapshots are captured outside the lock, so late subscribers converge (informer-style list-then-watch) without ordering gaps.
- endpoint watcher: optional netlink LinkSubscribe fast path that triggers an immediate reconcile on veth add/remove; resubscribes on any subscription error; retries interrupted dumps. Reconcile is level-triggered (re-asserts the full veth set each pass) so a missed event self-heals.
- attachment keying switched to interface index (stable across the pod-init rename that caused duplicate-key re-attach churn).
- packetparser: attach is idempotent and liveness-checked — a recorded attachment is re-verified against the kernel (TCX link ifindex / a targeted per-ifindex TC bpf-filter presence query) before being skipped, so a stale attachment (interface deleted+index reused, or programs detached) re-attaches on the next reconcile. Stop quiesces the endpoint callback (unsubscribe-first + barrier) so an in-flight attach can't race teardown and leak a live link. Attach error handling hardened: a non-fatal SetOption failure no longer tears down a successful attach, failed attaches release the rtnl socket, and neither the re-attach path nor the delete path ever deletes a clsact qdisc that may not be ours (a delete event or a dead probe can mean the index was reused, putting another agent's qdisc at our recorded ifindex — both paths release only our socket).
- apiserver / cache: level-triggered re-assert; commit-before-publish (closes a stale-delete window); deletes published before the add re-assert (a trailing delete wipes the cache's single apiserver key); synchronous ordered cache publish (fixes same-key add/delete reordering); non-IPv4 apiserver IPs skipped consistently in publishes and snapshots; cache snapshot sources registered explicitly by the daemon on the controller-fed cache (a constructor side effect on the pubsub singleton let an incidental second cache steal the snapshot slot).
- watcher-manager: reconciles once at startup and now logs-and-continues on refresh error instead of killing the watcher goroutine; Start unwinds already-started watchers if a later Init fails; Stop stops every watcher and always joins the goroutines.
- endpoint watcher lifecycle: Init derives an internal context and Stop cancels it — one teardown signal for the netlink goroutines, propagating parent cancellation.

Modes

- Disabled (default): periodic reconcile + all the above (ordered delivery, snapshot, level-triggering, liveness) — same timing as before, stronger convergence.
- Enabled: adds the netlink fast path (~ms attach) on top.

Correctness / performance

- Level-triggering means lost events never mean lost state — consumers converge on the next reconcile.
- Steady-state cost: each refresh re-verifies every attachment. Both TCX and legacy TC are O(1)/probe → O(N)/refresh — TCX via a single link.Info() syscall (~9 µs), TC via a targeted per-ifindex bpf-filter query (~280 µs, flat across 50/100/200 pods). No per-refresh full-qdisc sweep.
- No correctness regressions vs. the previous behavior; several fixes (watcher-dies-on-error, edge-triggered startup miss, unordered delivery, re-attach churn, stale attachments, attach-path fd leak, teardown races).
- The TC probe matches on filter presence, deliberately no stronger: its repair path is an EEXIST-tolerant Add, and a probe that detects more than the repair can fix turns unrepairable states into re-attach churn. The legacy-TC fallback's accepted gaps (duplicate ingress filter + stale egress program after an unclean restart until the veth churns; false-alive when a reused index carries another agent's bpf filter; conventional-slot contention with other legacy-TC agents; unconditional qdisc delete at Stop) are documented at tcAttachmentAlive/cleanAll — all absent under TCX, the preferred transport (kernel 6.6+).

Testing

- Unit: pubsub ordering/snapshot/unsubscribe/source-last-wins; watcher reuse detection (incl. across a failed re-list) + dump-interrupt retry + teardown; TCX & TC attach / liveness (alive, dead→re-attach, no foreign-qdisc delete on either the re-attach or delete path) / detach; attach failure paths (SetOption non-fatal, socket released, created-vs-pre-existing qdisc); Stop quiescence (post-Stop deliveries dropped; Stop blocks on an in-flight attach and cleans its attachment); apiserver snapshot (IPv4-filtered, race-tested against Refresh) + delete-before-add ordering; watcher-manager unwind/stop/initial-reconcile/survives-refresh-errors; cache ordering + snapshot sources (explicit registration pinned); config decode of the new keys. Race-clean.
- Real-kernel (-tags=ebpf): veth-churn attach latency; TCX & TC attach + liveness across interface delete; TC/TCX liveness-probe scale benchmarks.

Follow-ups (deferred)

- Convert packetparser's global test seams to instance DI (as done for the endpoint watcher).

</details>

## Checklist

- [X] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [X] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [X] I have correctly attributed the author(s) of the code.
- [X] I have tested the changes locally.
- [X] I have followed the project's style guidelines.
- [X] I have updated the documentation, if necessary.
- [X] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

Please add any relevant screenshots or GIFs to showcase the changes made.

## Additional Notes

Add any additional notes or context about the pull request here.

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
