### PR TITLE
feat(watchermanager): configurable refresh interval + hardened start/stop lifecycle

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -137,6 +137,7 @@ type Config struct {
 	PacketParserRingBufferSize uint32                     `yaml:"packetParserRingBufferSize"`
 	FilterMapMaxEntries        uint32                     `yaml:"filterMapMaxEntries"`
 	EnableTCX                  TCXMode                    `yaml:"enableTCX"`
+	WatcherRefreshInterval     time.Duration              `yaml:"watcherRefreshInterval"`
 }
 
 func GetConfig(cfgFilename string) (*Config, error) {

--- a/pkg/managers/pluginmanager/pluginmanager.go
+++ b/pkg/managers/pluginmanager/pluginmanager.go
@@ -57,7 +57,7 @@ func NewPluginManager(cfg *kcfg.Config, tel telemetry.Telemetry, logger *slog.Lo
 
 	if mgr.cfg.EnablePodLevel {
 		mgr.l.Info("plugin manager has pod level enabled")
-		mgr.watcherManager = watchermanager.NewWatcherManager(mgr.cfg.FilterMapMaxEntries)
+		mgr.watcherManager = watchermanager.NewWatcherManager(mgr.cfg.FilterMapMaxEntries, mgr.cfg.WatcherRefreshInterval)
 	} else {
 		mgr.l.Info("plugin manager has pod level disabled")
 	}

--- a/pkg/managers/watchermanager/watchermanager.go
+++ b/pkg/managers/watchermanager/watchermanager.go
@@ -19,14 +19,17 @@ const (
 	DefaultRefreshRate = 30 * time.Second
 )
 
-func NewWatcherManager(filterMapMaxEntries uint32) *WatcherManager {
+func NewWatcherManager(filterMapMaxEntries uint32, refreshRate time.Duration) *WatcherManager {
+	if refreshRate <= 0 {
+		refreshRate = DefaultRefreshRate
+	}
 	return &WatcherManager{
 		Watchers: []IWatcher{
 			endpoint.Watcher(),
 			apiserver.Watcher(filterMapMaxEntries),
 		},
 		l:           log.Logger().Named("watcher-manager"),
-		refreshRate: DefaultRefreshRate,
+		refreshRate: refreshRate,
 	}
 }
 
@@ -34,9 +37,21 @@ func (wm *WatcherManager) Start(ctx context.Context) error {
 	newCtx, cancelCtx := context.WithCancel(ctx)
 	wm.cancel = cancelCtx
 
-	for _, w := range wm.Watchers {
-		if err := w.Init(ctx); err != nil {
+	for i, w := range wm.Watchers {
+		// Init with the cancellable context so any long-lived goroutines a watcher
+		// starts (e.g. the endpoint watcher's netlink subscription) are torn down
+		// by wm.cancel() on Stop, consistent with runWatcher.
+		if err := w.Init(newCtx); err != nil {
 			wm.l.Error("init failed", zap.String("watcher_type", fmt.Sprintf("%T", w)), zap.Error(err))
+			// Unwind watchers already started so a failed Start leaves nothing
+			// running even if the caller never calls Stop.
+			cancelCtx()
+			for _, started := range wm.Watchers[:i] {
+				if stopErr := started.Stop(ctx); stopErr != nil {
+					wm.l.Error("failed to stop watcher during unwind", zap.String("watcher_type", fmt.Sprintf("%T", started)), zap.Error(stopErr))
+				}
+			}
+			wm.wg.Wait()
 			return err
 		}
 		wm.wg.Add(1)
@@ -50,31 +65,41 @@ func (wm *WatcherManager) Stop(ctx context.Context) error {
 	if wm.cancel != nil {
 		wm.cancel() // cancel all runWatcher
 	}
+	// Stop every watcher and always wait for the runWatcher goroutines; an early
+	// return on the first error would leave the rest running.
+	var firstErr error
 	for _, w := range wm.Watchers {
 		if err := w.Stop(ctx); err != nil {
 			wm.l.Error("failed to stop", zap.String("watcher_type", fmt.Sprintf("%T", w)), zap.Error(err))
-			return err
+			if firstErr == nil {
+				firstErr = err
+			}
 		}
 	}
 	wm.wg.Wait() // wait for all runWatcher to stop
 	wm.l.Info("watcher manager stopped")
-	return nil
+	return firstErr
 }
 
-func (wm *WatcherManager) runWatcher(ctx context.Context, w IWatcher) error {
+func (wm *WatcherManager) runWatcher(ctx context.Context, w IWatcher) {
 	defer wm.wg.Done() // signal that this runWatcher is done
+	// Reconcile once at startup instead of waiting for the first tick. Log and
+	// continue on failure so a transient error doesn't permanently kill the watcher.
+	if err := w.Refresh(ctx); err != nil {
+		wm.l.Error("initial refresh failed", zap.Error(err), zap.String("watcher_type", fmt.Sprintf("%T", w)))
+	}
 	ticker := time.NewTicker(wm.refreshRate)
 	defer ticker.Stop()
 	for {
 		select {
 		case <-ctx.Done():
 			wm.l.Info("watcher stopping...", zap.String("watcher_type", fmt.Sprintf("%T", w)))
-			return nil
+			return
 		case <-ticker.C:
-			err := w.Refresh(ctx)
-			if err != nil {
-				wm.l.Error("refresh failed", zap.Error(err))
-				return err
+			// Log and continue so a transient failure doesn't permanently stop
+			// reconciliation; the next tick retries.
+			if err := w.Refresh(ctx); err != nil {
+				wm.l.Error("refresh failed", zap.Error(err), zap.String("watcher_type", fmt.Sprintf("%T", w)))
 			}
 		}
 	}

--- a/pkg/managers/watchermanager/watchermanager_test.go
+++ b/pkg/managers/watchermanager/watchermanager_test.go
@@ -5,7 +5,9 @@ package watchermanager
 import (
 	"context"
 	"errors"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	kcfg "github.com/microsoft/retina/pkg/config"
 	"github.com/microsoft/retina/pkg/log"
@@ -21,7 +23,7 @@ func TestStopWatcherManagerGracefully(t *testing.T) {
 	ctl := gomock.NewController(t)
 	defer ctl.Finish()
 	log.SetupZapLogger(log.GetDefaultLogOpts())
-	mgr := NewWatcherManager(kcfg.DefaultFilterMapMaxEntries)
+	mgr := NewWatcherManager(kcfg.DefaultFilterMapMaxEntries, 0)
 
 	mockAPIServerWatcher := mock.NewMockIWatcher(ctl)
 	mockEndpointWatcher := mock.NewMockIWatcher(ctl)
@@ -34,10 +36,14 @@ func TestStopWatcherManagerGracefully(t *testing.T) {
 	mockAPIServerWatcher.EXPECT().Init(gomock.Any()).Return(nil).AnyTimes()
 	mockEndpointWatcher.EXPECT().Init(gomock.Any()).Return(nil).AnyTimes()
 
+	mockEndpointWatcher.EXPECT().Refresh(gomock.Any()).Return(nil).AnyTimes()
+	mockAPIServerWatcher.EXPECT().Refresh(gomock.Any()).Return(nil).AnyTimes()
+
 	mockEndpointWatcher.EXPECT().Stop(gomock.Any()).Return(nil).AnyTimes()
 	mockAPIServerWatcher.EXPECT().Stop(gomock.Any()).Return(nil).AnyTimes()
 
-	ctx, _ := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	g, errctx := errgroup.WithContext(ctx)
 
 	g.Go(func() error {
@@ -57,7 +63,7 @@ func TestWatcherInitFailsGracefully(t *testing.T) {
 	mockAPIServerWatcher := mock.NewMockIWatcher(ctl)
 	mockEndpointWatcher := mock.NewMockIWatcher(ctl)
 
-	mgr := NewWatcherManager(kcfg.DefaultFilterMapMaxEntries)
+	mgr := NewWatcherManager(kcfg.DefaultFilterMapMaxEntries, 0)
 	mgr.Watchers = []IWatcher{
 		mockAPIServerWatcher,
 		mockEndpointWatcher,
@@ -70,12 +76,116 @@ func TestWatcherInitFailsGracefully(t *testing.T) {
 	require.NotNil(t, err, "Expected error when starting watcher manager")
 }
 
+// A failed Init partway through Start must unwind: already-started watchers are
+// stopped and their runWatcher goroutines joined, so a caller that treats the
+// error as fatal (never calling Stop) leaks nothing.
+func TestStartUnwindsOnInitFailure(t *testing.T) {
+	ctl := gomock.NewController(t)
+	defer ctl.Finish()
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
+
+	first := mock.NewMockIWatcher(ctl)
+	second := mock.NewMockIWatcher(ctl)
+
+	mgr := NewWatcherManager(kcfg.DefaultFilterMapMaxEntries, 0)
+	mgr.Watchers = []IWatcher{first, second}
+
+	first.EXPECT().Init(gomock.Any()).Return(nil).Times(1)
+	first.EXPECT().Refresh(gomock.Any()).Return(nil).AnyTimes()
+	// The unwind must stop the watcher that already started.
+	first.EXPECT().Stop(gomock.Any()).Return(nil).Times(1)
+	second.EXPECT().Init(gomock.Any()).Return(errInitFailed).Times(1)
+
+	err := mgr.Start(context.Background())
+	require.ErrorIs(t, err, errInitFailed)
+	// wg.Wait inside Start already joined first's runWatcher; a second Stop must
+	// also be safe (idempotent from the caller's perspective).
+	first.EXPECT().Stop(gomock.Any()).Return(nil).Times(1)
+	second.EXPECT().Stop(gomock.Any()).Return(nil).Times(1)
+	require.NoError(t, mgr.Stop(context.Background()))
+}
+
+// Stop must attempt every watcher and wait for the goroutines even when one
+// watcher's Stop fails; the first error is reported.
+func TestStopContinuesPastFailedWatcher(t *testing.T) {
+	ctl := gomock.NewController(t)
+	defer ctl.Finish()
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
+
+	failing := mock.NewMockIWatcher(ctl)
+	healthy := mock.NewMockIWatcher(ctl)
+
+	mgr := NewWatcherManager(kcfg.DefaultFilterMapMaxEntries, 0)
+	mgr.Watchers = []IWatcher{failing, healthy}
+
+	failing.EXPECT().Stop(gomock.Any()).Return(errInitFailed).Times(1)
+	// The second watcher must still be stopped.
+	healthy.EXPECT().Stop(gomock.Any()).Return(nil).Times(1)
+
+	err := mgr.Stop(context.Background())
+	require.ErrorIs(t, err, errInitFailed)
+}
+
+// A watcher must reconcile once at startup, not wait for the first tick.
+func TestRunWatcherInitialReconcile(t *testing.T) {
+	ctl := gomock.NewController(t)
+	defer ctl.Finish()
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
+
+	w := mock.NewMockIWatcher(ctl)
+	mgr := NewWatcherManager(kcfg.DefaultFilterMapMaxEntries, time.Hour) // no tick fires during the test
+	mgr.Watchers = []IWatcher{w}
+
+	refreshed := make(chan struct{}, 1)
+	w.EXPECT().Init(gomock.Any()).Return(nil).Times(1)
+	w.EXPECT().Refresh(gomock.Any()).DoAndReturn(func(context.Context) error {
+		select {
+		case refreshed <- struct{}{}:
+		default:
+		}
+		return nil
+	}).Times(1)
+	w.EXPECT().Stop(gomock.Any()).Return(nil).Times(1)
+
+	require.NoError(t, mgr.Start(context.Background()))
+	select {
+	case <-refreshed:
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected a reconcile at startup, before the first tick")
+	}
+	require.NoError(t, mgr.Stop(context.Background()))
+}
+
+// A failing Refresh must not kill the watcher goroutine; the next tick retries.
+func TestRunWatcherSurvivesRefreshErrors(t *testing.T) {
+	ctl := gomock.NewController(t)
+	defer ctl.Finish()
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
+
+	w := mock.NewMockIWatcher(ctl)
+	mgr := NewWatcherManager(kcfg.DefaultFilterMapMaxEntries, 10*time.Millisecond)
+	mgr.Watchers = []IWatcher{w}
+
+	var calls atomic.Int32
+	w.EXPECT().Init(gomock.Any()).Return(nil).Times(1)
+	w.EXPECT().Refresh(gomock.Any()).DoAndReturn(func(context.Context) error {
+		calls.Add(1)
+		return errInitFailed
+	}).AnyTimes()
+	w.EXPECT().Stop(gomock.Any()).Return(nil).Times(1)
+
+	require.NoError(t, mgr.Start(context.Background()))
+	require.Eventually(t, func() bool { return calls.Load() >= 3 }, 2*time.Second, 5*time.Millisecond,
+		"refresh errors must be logged and retried, not terminate the watcher")
+	require.NoError(t, mgr.Stop(context.Background()))
+}
+
 func TestWatcherStopWithoutStart(t *testing.T) {
 	ctl := gomock.NewController(t)
 	defer ctl.Finish()
 	log.SetupZapLogger(log.GetDefaultLogOpts())
 
-	mgr := NewWatcherManager(kcfg.DefaultFilterMapMaxEntries)
+	mgr := NewWatcherManager(kcfg.DefaultFilterMapMaxEntries, 0)
 
 	err := mgr.Stop(context.Background())
 	require.Nil(t, err, "Expected no error when stopping watcher manager without starting it")

--- a/test/managers/filtermanager/main.go
+++ b/test/managers/filtermanager/main.go
@@ -39,7 +39,7 @@ func main() {
 	ctx := context.Background()
 
 	// watcher manager
-	wm := watchermanager.NewWatcherManager(kcfg.DefaultFilterMapMaxEntries)
+	wm := watchermanager.NewWatcherManager(kcfg.DefaultFilterMapMaxEntries, 0)
 	wm.Watchers = []watchermanager.IWatcher{endpoint.Watcher(), apiserver.Watcher(kcfg.DefaultFilterMapMaxEntries)}
 
 	err := wm.Start(ctx)

--- a/test/plugin/packetparser/main_linux.go
+++ b/test/plugin/packetparser/main_linux.go
@@ -33,7 +33,7 @@ func main() {
 	ctxTimeout, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 
 	// watcher manager
-	wm := watchermanager.NewWatcherManager(kcfg.DefaultFilterMapMaxEntries)
+	wm := watchermanager.NewWatcherManager(kcfg.DefaultFilterMapMaxEntries, 0)
 	wm.Watchers = []watchermanager.IWatcher{endpoint.Watcher()}
 
 	err := wm.Start(ctxTimeout)

--- a/test/watchers/apiserver/main.go
+++ b/test/watchers/apiserver/main.go
@@ -36,7 +36,7 @@ func main() {
 		}
 	}()
 	// watcher manager
-	wm := watchermanager.NewWatcherManager(kcfg.DefaultFilterMapMaxEntries)
+	wm := watchermanager.NewWatcherManager(kcfg.DefaultFilterMapMaxEntries, 0)
 	wm.Watchers = []watchermanager.IWatcher{apiserver.Watcher(kcfg.DefaultFilterMapMaxEntries)}
 
 	// apiserver watcher.

--- a/test/watchers/veth/main.go
+++ b/test/watchers/veth/main.go
@@ -24,7 +24,7 @@ func main() {
 	ctx := context.Background()
 
 	// watcher manager
-	wm := watchermanager.NewWatcherManager(kcfg.DefaultFilterMapMaxEntries)
+	wm := watchermanager.NewWatcherManager(kcfg.DefaultFilterMapMaxEntries, 0)
 	wm.Watchers = []watchermanager.IWatcher{endpoint.Watcher()}
 
 	err := wm.Start(ctx)


### PR DESCRIPTION
# Description

**Stack 3/5** (splits #9) — base `split/2-packetparser` (review after #11).

Configurable watcher refresh interval plus a hardened watcher-manager start/stop lifecycle.

- `watcherRefreshInterval` config (default `30s`) threaded to `NewWatcherManager`; `<=0` falls back to the default.
- **Reconcile once at startup** instead of waiting a full interval for the first tick.
- **Log-and-continue** on a refresh error instead of terminating the watcher goroutine.
- `Start` **unwinds** already-started watchers (cancel + stop + join) if a later watcher's `Init` fails, so a failed `Start` leaves nothing running even if the caller never calls `Stop`.
- `Stop` stops **every** watcher and always joins the goroutines, reporting the first error instead of bailing on it.

## Related Issue

Splits #9 into a reviewable stack; this is part 3 of 5.

## Checklist

- [ ] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [x] I signed and signed-off the commits (`git commit -S -s ...`).
- [x] I have correctly attributed the author(s) of the code.
- [x] I have tested the changes locally.
- [x] I have followed the project's style guidelines.
- [x] I have updated the documentation, if necessary.
- [x] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

Start-unwind-on-init-failure (incl. idempotent second Stop), stop-continues-past-a-failing-watcher, initial reconcile at startup, survives-refresh-errors (retries next tick), refresh-rate default.

## Additional Notes

Stack (review in order): 1 pubsub (#10) → 2 packetparser (#11) → **3 watchermanager** → 4 apiserver/cache (#13) → 5 endpoint/netlink (#14). Rebased on latest `microsoft/main`.
