### PR TITLE
feat(pubsub): ordered per-subscriber delivery + snapshot-on-subscribe

### DIFF
--- a/pkg/pubsub/mock_pubsubinterface.go
+++ b/pkg/pubsub/mock_pubsubinterface.go
@@ -56,6 +56,18 @@ func (mr *MockPubSubInterfaceMockRecorder) Publish(arg0, arg1 any) *gomock.Call 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Publish", reflect.TypeOf((*MockPubSubInterface)(nil).Publish), arg0, arg1)
 }
 
+// RegisterSource mocks base method.
+func (m *MockPubSubInterface) RegisterSource(arg0 PubSubTopic, arg1 func() []any) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "RegisterSource", arg0, arg1)
+}
+
+// RegisterSource indicates an expected call of RegisterSource.
+func (mr *MockPubSubInterfaceMockRecorder) RegisterSource(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterSource", reflect.TypeOf((*MockPubSubInterface)(nil).RegisterSource), arg0, arg1)
+}
+
 // Subscribe mocks base method.
 func (m *MockPubSubInterface) Subscribe(arg0 PubSubTopic, arg1 *CallBackFunc) string {
 	m.ctrl.T.Helper()

--- a/pkg/pubsub/pubsub.go
+++ b/pkg/pubsub/pubsub.go
@@ -5,109 +5,255 @@ package pubsub
 import (
 	"fmt"
 	"sync"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/microsoft/retina/pkg/log"
 	"go.uber.org/zap"
 )
 
+// latencyWarnThreshold is the delivery lag — the age of the oldest undelivered
+// event — at which we warn that a consumer is falling behind. Latency, not queue
+// depth: depth is a poor proxy because per-event cost varies by orders of
+// magnitude (a re-assert skip is tens of µs, a fresh attach is milliseconds), so
+// the same depth can mean tens of ms or several seconds of lag. The queue is
+// unbounded (events are never dropped) and the fast path targets ms-scale
+// delivery, so a lag this large means the fast path is degraded well before it
+// matters.
+const latencyWarnThreshold = 1 * time.Second
+
 var (
 	p    *PubSub
 	once sync.Once
 )
 
-type PubSub struct {
-	sync.RWMutex
-	// l is the logger.
-	l *log.ZapLogger
-	// topicToCallback is a map of topic to a map of callback function
-	topicToCallback map[PubSubTopic]map[string]*CallBackFunc
+// subscriber buffers events in an unbounded, ordered queue drained by a single
+// goroutine. Ordering guarantees the initial snapshot is delivered before any
+// later event (e.g. a delete). It never drops and never blocks the publisher, so
+// one slow subscriber cannot stall the shared publisher. Mirrors client-go's
+// shared informer processorListener.
+//
+// Delivery does not begin until start() runs: Subscribe makes the subscriber
+// visible to publishers first (so live events buffer into pending), then start()
+// prepends the snapshot ahead of anything buffered and opens the gate. This lets
+// snapshot() run outside the PubSub lock — it must never be called under the lock
+// because a source may take other locks (or do I/O), which would risk deadlock
+// and stall every topic.
+type subscriber struct {
+	id    string
+	topic PubSubTopic
+	cb    *CallBackFunc
+	l     *log.ZapLogger
+
+	mu      sync.Mutex
+	cond    *sync.Cond
+	pending []queued
+	started bool
+	stopped bool
+	warned  bool
 }
 
-// New returns a new instance of PubSub.
+// queued is an event plus the time it was enqueued, so delivery lag (the age of
+// the oldest undelivered event) can be measured.
+type queued struct {
+	msg interface{}
+	at  time.Time
+}
+
+func newSubscriber(id string, topic PubSubTopic, cb *CallBackFunc, l *log.ZapLogger) *subscriber {
+	s := &subscriber{id: id, topic: topic, cb: cb, l: l}
+	s.cond = sync.NewCond(&s.mu)
+	go s.run()
+	return s
+}
+
+// enqueue appends an event. It never blocks the publisher and never drops.
+func (s *subscriber) enqueue(msg interface{}) {
+	s.mu.Lock()
+	if s.stopped {
+		s.mu.Unlock()
+		return
+	}
+	s.pending = append(s.pending, queued{msg: msg, at: time.Now()})
+	// Warn on delivery lag — the age of the oldest undelivered event — evaluated
+	// here at enqueue so a fully stalled consumer (which never dequeues, so a
+	// dequeue-time measurement would go silent) is still caught. One-shot until
+	// the queue drains, to avoid log spam.
+	if age := time.Since(s.pending[0].at); age >= latencyWarnThreshold && !s.warned {
+		s.warned = true
+		s.l.Warn("pubsub subscriber delivery lag is high; consumer is falling behind",
+			zap.String("topic", string(s.topic)), zap.String("uuid", s.id),
+			zap.Duration("lag", age), zap.Int("depth", len(s.pending)))
+	}
+	s.mu.Unlock()
+	s.cond.Signal()
+}
+
+// start prepends the initial snapshot ahead of any events buffered since the
+// subscriber became visible, then opens the delivery gate. Snapshot items are
+// therefore delivered before every later event, while events that raced in during
+// subscription still follow (idempotent consumers absorb any overlap).
+func (s *subscriber) start(snapshot []interface{}) {
+	s.mu.Lock()
+	if len(snapshot) > 0 {
+		now := time.Now()
+		q := make([]queued, 0, len(snapshot)+len(s.pending))
+		for i := range snapshot {
+			q = append(q, queued{msg: snapshot[i], at: now})
+		}
+		q = append(q, s.pending...)
+		s.pending = q
+	}
+	s.started = true
+	s.mu.Unlock()
+	s.cond.Signal()
+}
+
+func (s *subscriber) run() {
+	s.mu.Lock()
+	for {
+		for !s.stopped && (!s.started || len(s.pending) == 0) {
+			s.cond.Wait()
+		}
+		if s.stopped {
+			s.mu.Unlock()
+			return
+		}
+		msg := s.pending[0].msg
+		s.pending[0] = queued{} // release references
+		s.pending = s.pending[1:]
+		if len(s.pending) == 0 {
+			s.pending = nil // release backing array once drained
+			s.warned = false
+		}
+		s.mu.Unlock()
+
+		// Callbacks are trusted code; a panic here is a bug and crashes the agent
+		// rather than being silently swallowed.
+		(*s.cb)(msg)
+
+		s.mu.Lock()
+	}
+}
+
+func (s *subscriber) stop() {
+	s.mu.Lock()
+	s.stopped = true
+	s.mu.Unlock()
+	s.cond.Broadcast()
+}
+
+type PubSub struct {
+	sync.RWMutex
+	l *log.ZapLogger
+	// subscribers maps a topic to its subscribers keyed by id.
+	subscribers map[PubSubTopic]map[string]*subscriber
+	// sources maps a topic to a snapshot provider replayed to new subscribers.
+	sources map[PubSubTopic]func() []interface{}
+}
+
+// New returns the singleton PubSub instance.
 func New() *PubSub {
 	once.Do(func() {
 		p = &PubSub{
-			l:               log.Logger().Named(string("PubSub")),
-			topicToCallback: make(map[PubSubTopic]map[string]*CallBackFunc),
+			l:           log.Logger().Named(string("PubSub")),
+			subscribers: make(map[PubSubTopic]map[string]*subscriber),
+			sources:     make(map[PubSubTopic]func() []interface{}),
 		}
 	})
 
 	return p
 }
 
-// Publish publishes the given message to the given topic,
-// and calls all the callback functions subscribed to the topic.
+// RegisterSource registers a snapshot provider for a topic. When a new
+// subscriber subscribes, the current snapshot is replayed to it before any
+// later event, so a subscriber that registers after events were published still
+// converges to the current state (informer-style list-then-watch). Callbacks
+// must be idempotent: a snapshot item may duplicate a concurrently published event.
+func (p *PubSub) RegisterSource(topic PubSubTopic, snapshot func() []interface{}) {
+	p.Lock()
+	defer p.Unlock()
+	p.sources[topic] = snapshot
+}
+
+// Publish enqueues msg to every current subscriber of the topic.
 func (p *PubSub) Publish(topic PubSubTopic, msg interface{}) {
 	p.RLock()
 	defer p.RUnlock()
 
-	// If there are no callbacks for the given topic, return nil.
-	if _, ok := p.topicToCallback[topic]; !ok {
-		p.l.Debug("no callbacks for topic", zap.String("topic", string(topic)))
+	subs := p.subscribers[topic]
+	if len(subs) == 0 {
+		// Not an error: with level-triggered re-assertion, publishing before a
+		// subscriber has joined is routine and self-heals on the next refresh.
+		p.l.Debug("no subscribers for topic", zap.String("topic", string(topic)))
 		return
 	}
 
-	// Run all callbacks in parallel using a wait group.
-	for uuid, callback := range p.topicToCallback[topic] {
-		callback := callback
-		p.l.Debug("running callback", zap.String("topic", string(topic)), zap.String("uuid", uuid))
-		go func() {
-			(*callback)(msg)
-		}()
+	for _, s := range subs {
+		s.enqueue(msg)
 	}
 }
 
-// Subscribe subscribes to the given topic and calls the given callback function
-// when a message is published to the topic, it returns a new uuid of the callback.
+// Subscribe registers callback for the topic and returns its id. If a source is
+// registered, its current snapshot is delivered to this subscriber before any
+// later event (informer-style list-then-watch); callbacks must be idempotent, as
+// a snapshot item may overlap a concurrently published event.
+//
+// The subscriber is made visible under the lock (so live events start buffering),
+// but snapshot() is invoked *after* releasing the lock and then prepended ahead of
+// anything buffered. This preserves ordering without holding the PubSub lock across
+// the source callback, which may take other locks or do I/O.
 func (p *PubSub) Subscribe(topic PubSubTopic, callback *CallBackFunc) string {
+	id := uuid.New().String()
+	s := newSubscriber(id, topic, callback, p.l)
+
 	p.Lock()
-	defer p.Unlock()
-
-	// If the topic does not exist, create it.
-	if _, ok := p.topicToCallback[topic]; !ok {
-		p.topicToCallback[topic] = make(map[string]*CallBackFunc)
+	if p.subscribers[topic] == nil {
+		p.subscribers[topic] = make(map[string]*subscriber)
 	}
+	p.subscribers[topic][id] = s
+	source := p.sources[topic]
+	p.Unlock()
 
-	// Generate a new uuid for the callback.
-	uuid := uuid.New().String()
-	// Add the callback to the topic.
-	p.topicToCallback[topic][uuid] = callback
-	p.l.Debug("subscribed to topic", zap.String("topic", string(topic)), zap.String("uuid", uuid))
+	// Captured outside the lock; ordering is preserved because s buffers any
+	// events published in this window and start() prepends the snapshot ahead of
+	// them. A snapshot taken here reflects all state up to this point, so nothing
+	// is missed: earlier events are in the snapshot, later ones are buffered.
+	var snapshot []interface{}
+	if source != nil {
+		snapshot = source()
+	}
+	s.start(snapshot)
 
-	return uuid
+	p.l.Debug("subscribed to topic", zap.String("topic", string(topic)), zap.String("uuid", id))
+	return id
 }
 
-// Unsubscribe unsubscribes from the given topic.
+// Unsubscribe removes the subscriber and stops its drain goroutine. It does
+// NOT wait for a delivery already in flight: the callback may still be running
+// (or run once more) after Unsubscribe returns. Callers that tear down state
+// the callback uses must synchronize in the callback itself (see packetparser's
+// stopping/cbMu handshake).
 func (p *PubSub) Unsubscribe(topic PubSubTopic, uuid string) error {
-	p.Lock()
-	defer p.Unlock()
-
 	if uuid == "" {
 		return fmt.Errorf("uuid cannot be empty")
 	}
 
-	// If the topic does not exist, return nil.
-	if _, ok := p.topicToCallback[topic]; !ok {
-		p.l.Debug("no callbacks for topic", zap.String("topic", string(topic)))
-		return nil
+	p.Lock()
+	var s *subscriber
+	if subs, ok := p.subscribers[topic]; ok {
+		if s = subs[uuid]; s != nil {
+			delete(subs, uuid)
+			if len(subs) == 0 {
+				delete(p.subscribers, topic)
+			}
+		}
 	}
+	p.Unlock()
 
-	// If the callback does not exist, return nil.
-	if _, ok := p.topicToCallback[topic][uuid]; !ok {
-		p.l.Debug("callback does not exist", zap.String("topic", string(topic)), zap.String("uuid", uuid))
-		return nil
+	if s != nil {
+		s.stop()
+		p.l.Debug("unsubscribed from topic", zap.String("topic", string(topic)), zap.String("uuid", uuid))
 	}
-
-	// Delete the callback from the topic.
-	delete(p.topicToCallback[topic], uuid)
-	p.l.Debug("unsubscribed from topic", zap.String("topic", string(topic)), zap.String("uuid", uuid))
-
-	// Delete the topic if there are no callbacks left.
-	if len(p.topicToCallback[topic]) == 0 {
-		delete(p.topicToCallback, topic)
-		p.l.Debug("deleted topic", zap.String("topic", string(topic)))
-	}
-
 	return nil
 }

--- a/pkg/pubsub/pubsub_test.go
+++ b/pkg/pubsub/pubsub_test.go
@@ -3,11 +3,13 @@
 package pubsub
 
 import (
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/microsoft/retina/pkg/log"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -15,19 +17,19 @@ const (
 )
 
 func TestNewPubSub(t *testing.T) {
-	log.SetupZapLogger(log.GetDefaultLogOpts())
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
 	p := New()
 	assert.NotNil(t, p)
 }
 
 func TestPublish(t *testing.T) {
-	log.SetupZapLogger(log.GetDefaultLogOpts())
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
 	p := New()
 	p.Publish("topic", "msg")
 }
 
 func TestSubscribe(t *testing.T) {
-	log.SetupZapLogger(log.GetDefaultLogOpts())
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
 	p := New()
 	cb := CallBackFunc(func(msg interface{}) {})
 
@@ -36,7 +38,7 @@ func TestSubscribe(t *testing.T) {
 }
 
 func TestUnsubscribe(t *testing.T) {
-	log.SetupZapLogger(log.GetDefaultLogOpts())
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
 	p := New()
 	cb := CallBackFunc(func(msg interface{}) {})
 
@@ -46,7 +48,7 @@ func TestUnsubscribe(t *testing.T) {
 }
 
 func TestMultipleSubscribe(t *testing.T) {
-	log.SetupZapLogger(log.GetDefaultLogOpts())
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
 
 	cb := CallBackFunc(func(msg interface{}) {})
 
@@ -58,7 +60,7 @@ func TestMultipleSubscribe(t *testing.T) {
 }
 
 func TestPubSub(t *testing.T) {
-	log.SetupZapLogger(log.GetDefaultLogOpts())
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
 	ps := New()
 
 	// Publisher 1 publishes a message to topic "topic1"
@@ -111,4 +113,281 @@ func TestPubSub(t *testing.T) {
 	}
 
 	time.Sleep(until)
+}
+
+func TestSubscribeReplaysSnapshot(t *testing.T) {
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
+	p := New()
+
+	// Source registered before anyone subscribes.
+	p.RegisterSource("snap-topic", func() []interface{} {
+		return []interface{}{"a", "b"}
+	})
+
+	var mu sync.Mutex
+	got := map[string]bool{}
+	cb := CallBackFunc(func(msg interface{}) {
+		mu.Lock()
+		got[msg.(string)] = true
+		mu.Unlock()
+	})
+
+	// Subscriber joins late; it must still receive the current snapshot.
+	id := p.Subscribe("snap-topic", &cb)
+	defer p.Unsubscribe("snap-topic", id) //nolint:errcheck // best-effort cleanup in test
+
+	assert.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return got["a"] && got["b"]
+	}, time.Second, 5*time.Millisecond, "expected snapshot replayed to a late subscriber")
+}
+
+func TestSnapshotDeliveredBeforeDeltas(t *testing.T) {
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
+	p := New()
+
+	p.RegisterSource("order-topic", func() []interface{} {
+		return []interface{}{"snapshot-add"}
+	})
+
+	var mu sync.Mutex
+	var order []string
+	cb := CallBackFunc(func(msg interface{}) {
+		mu.Lock()
+		order = append(order, msg.(string))
+		mu.Unlock()
+	})
+
+	id := p.Subscribe("order-topic", &cb)
+	defer p.Unsubscribe("order-topic", id) //nolint:errcheck // best-effort cleanup in test
+
+	// Subscribe enqueues the snapshot under the lock, so this later delta is
+	// ordered after it. FIFO delivery must yield snapshot-then-delta.
+	p.Publish("order-topic", "live-delete")
+
+	assert.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return len(order) == 2
+	}, time.Second, 5*time.Millisecond, "expected both events delivered")
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Equal(t, []string{"snapshot-add", "live-delete"}, order,
+		"snapshot must be delivered before later deltas (e.g. deletes)")
+}
+
+func TestSnapshotSourceRunsOutsideLock(t *testing.T) {
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
+	p := New()
+
+	// A snapshot source that re-enters PubSub (Publish takes the read lock).
+	// This deadlocks if snapshot() is invoked while the Subscribe path holds the
+	// write lock — the regression this guards against. Real sources instead take
+	// their own locks / do I/O, which is the same hazard (deadlock, or stalling
+	// every topic across a syscall).
+	p.RegisterSource("reentrant-topic", func() []interface{} {
+		p.Publish("sink-topic", "from-snapshot")
+		return []interface{}{"snap"}
+	})
+
+	sink := make(chan string, 1)
+	sinkCb := CallBackFunc(func(m interface{}) { sink <- m.(string) })
+	p.Subscribe("sink-topic", &sinkCb)
+
+	got := make(chan string, 1)
+	cb := CallBackFunc(func(m interface{}) { got <- m.(string) })
+
+	done := make(chan string, 1)
+	go func() { done <- p.Subscribe("reentrant-topic", &cb) }()
+
+	// Subscribe must return (no deadlock), the snapshot item must be delivered,
+	// and the event the source published must reach the sink subscriber.
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Subscribe hung; snapshot() appears to run under the PubSub lock")
+	}
+	select {
+	case v := <-got:
+		assert.Equal(t, "snap", v, "snapshot item should be delivered")
+	case <-time.After(time.Second):
+		t.Fatal("snapshot item not delivered")
+	}
+	select {
+	case v := <-sink:
+		assert.Equal(t, "from-snapshot", v, "event published from within snapshot should be delivered")
+	case <-time.After(time.Second):
+		t.Fatal("event published from within snapshot not delivered")
+	}
+}
+
+// TestDeltasDuringSubscribeFollowSnapshot pins the subscriber start-gate
+// invariant: an event published while the snapshot source is still running (the
+// subscriber is already visible to publishers, but delivery hasn't started) must
+// buffer and be delivered AFTER the snapshot, never before and never dropped.
+func TestDeltasDuringSubscribeFollowSnapshot(t *testing.T) {
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
+	p := New()
+
+	sourceEntered := make(chan struct{})
+	releaseSource := make(chan struct{})
+	p.RegisterSource("gate-topic", func() []interface{} {
+		close(sourceEntered)
+		<-releaseSource // hold the subscription open while the test publishes
+		return []interface{}{"snap"}
+	})
+
+	var mu sync.Mutex
+	var order []string
+	cb := CallBackFunc(func(m interface{}) {
+		mu.Lock()
+		order = append(order, m.(string))
+		mu.Unlock()
+	})
+
+	subscribed := make(chan string, 1)
+	go func() { subscribed <- p.Subscribe("gate-topic", &cb) }()
+
+	<-sourceEntered
+	// Subscriber is registered (visible) but gated; this must buffer, not drop.
+	p.Publish("gate-topic", "delta")
+	close(releaseSource)
+
+	id := <-subscribed
+	defer p.Unsubscribe("gate-topic", id) //nolint:errcheck // best-effort cleanup in test
+
+	assert.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return len(order) == 2
+	}, 2*time.Second, 5*time.Millisecond, "both the snapshot and the buffered delta must be delivered")
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Equal(t, []string{"snap", "delta"}, order,
+		"a delta buffered during subscription must follow the snapshot")
+}
+
+// TestPublishDeliversInFIFOOrder pins per-subscriber FIFO: events published
+// sequentially to a topic are delivered to a subscriber in publish order. The
+// snapshot-ordering tests only cover one live event relative to the snapshot;
+// this guards the delta-vs-delta ordering the single drain goroutine provides.
+func TestPublishDeliversInFIFOOrder(t *testing.T) {
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
+	p := New()
+
+	const n = 100
+	var mu sync.Mutex
+	var got []int
+	cb := CallBackFunc(func(m interface{}) {
+		mu.Lock()
+		got = append(got, m.(int))
+		mu.Unlock()
+	})
+	id := p.Subscribe("fifo-topic", &cb)
+	defer p.Unsubscribe("fifo-topic", id) //nolint:errcheck // best-effort cleanup in test
+
+	// Single sequential publisher: publish order is 0..n-1.
+	for i := 0; i < n; i++ {
+		p.Publish("fifo-topic", i)
+	}
+
+	assert.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return len(got) == n
+	}, 2*time.Second, 5*time.Millisecond, "all published events must be delivered")
+
+	mu.Lock()
+	defer mu.Unlock()
+	want := make([]int, n)
+	for i := range want {
+		want[i] = i
+	}
+	assert.Equal(t, want, got, "events must be delivered in publish order (per-subscriber FIFO)")
+}
+
+// newTestSubscriber builds a subscriber without starting its drain goroutine,
+// so seeded pending events aren't consumed before the assertion.
+func newTestSubscriber() *subscriber {
+	s := &subscriber{id: "t", topic: "lag-topic", l: log.Logger()}
+	s.cond = sync.NewCond(&s.mu)
+	return s
+}
+
+// enqueue warns on delivery lag — the age of the oldest undelivered event —
+// evaluated at enqueue so a stalled consumer is caught, and stays quiet on a
+// queue that isn't behind.
+func TestEnqueueWarnsOnDeliveryLag(t *testing.T) {
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
+
+	// A head that has already waited past the threshold (as a stalled consumer's
+	// would) must trip the warning on the next enqueue.
+	lagging := newTestSubscriber()
+	lagging.pending = []queued{{msg: "old", at: time.Now().Add(-2 * latencyWarnThreshold)}}
+	lagging.enqueue("new")
+	assert.True(t, lagging.warned, "a head-of-queue older than the latency threshold must warn")
+
+	// A just-enqueued (near-zero-age) head must not warn.
+	fresh := newTestSubscriber()
+	fresh.enqueue("m1")
+	fresh.enqueue("m2")
+	assert.False(t, fresh.warned, "a queue that is not behind must not warn")
+}
+
+func TestUnsubscribeStopsDelivery(t *testing.T) {
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
+	p := New()
+
+	got := make(chan struct{}, 8)
+	cb := CallBackFunc(func(interface{}) { got <- struct{}{} })
+	id := p.Subscribe("unsub-topic", &cb)
+
+	p.Publish("unsub-topic", "m1")
+	select {
+	case <-got:
+	case <-time.After(time.Second):
+		t.Fatal("first event was not delivered")
+	}
+
+	require.NoError(t, p.Unsubscribe("unsub-topic", id))
+
+	// After unsubscribe the drain goroutine is stopped and the subscriber removed,
+	// so a later publish must not be delivered.
+	p.Publish("unsub-topic", "m2")
+	select {
+	case <-got:
+		t.Fatal("event delivered after unsubscribe")
+	case <-time.After(200 * time.Millisecond):
+	}
+}
+
+// RegisterSource keeps only the most recent source for a topic (last writer
+// wins) — the semantic the cache's explicit RegisterSnapshotSources wiring
+// depends on: whichever component registers last owns the topic's snapshot slot.
+func TestRegisterSourceLastWins(t *testing.T) {
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
+	p := New()
+	topic := PubSubTopic("last-wins-topic")
+	p.RegisterSource(topic, func() []interface{} { return []interface{}{"stale"} })
+	p.RegisterSource(topic, func() []interface{} { return []interface{}{"current"} })
+
+	got := make(chan interface{}, 2)
+	cb := CallBackFunc(func(msg interface{}) { got <- msg })
+	id := p.Subscribe(topic, &cb)
+	defer p.Unsubscribe(topic, id) //nolint:errcheck // best-effort cleanup in test
+
+	select {
+	case msg := <-got:
+		assert.Equal(t, "current", msg, "the last registered source must serve the snapshot")
+	case <-time.After(2 * time.Second):
+		t.Fatal("no snapshot delivered")
+	}
+	select {
+	case msg := <-got:
+		t.Fatalf("the overwritten source must not also fire, got: %v", msg)
+	case <-time.After(100 * time.Millisecond):
+	}
 }

--- a/pkg/pubsub/types.go
+++ b/pkg/pubsub/types.go
@@ -15,6 +15,8 @@ type PubSubInterface interface {
 	Subscribe(topic PubSubTopic, callback *CallBackFunc) string
 	// Unsubscribe unsubscribes from the given topic
 	Unsubscribe(topic PubSubTopic, uuid string) error
+	// RegisterSource registers a snapshot provider replayed to new subscribers
+	RegisterSource(topic PubSubTopic, snapshot func() []interface{})
 }
 
 type PubSubTopic string


### PR DESCRIPTION
# Description

**Stack 1/5** (splits #9 into reviewable pieces) — base `main`.

Introduces per-subscriber **ordered FIFO delivery** and **snapshot-on-subscribe** for pubsub, replacing the previous unordered goroutine-per-callback dispatch. This is the foundation for the informer-style "list-then-watch" convergence the rest of the stack relies on.

- Each subscriber gets its own queue + drain goroutine, so events arrive in publish order per subscriber (a prior add and a later delete of the same key can no longer arrive reversed).
- `RegisterSource(topic, snapshot)` lets a source provide a snapshot; `Subscribe` captures it outside the lock and prepends it ahead of buffered live events via a start-gate, so a late subscriber converges without an ordering gap or lost event.
- `Unsubscribe` stops the drain goroutine; its doc notes it does **not** join an in-flight callback.
- Publish only enqueues (callbacks run on the drain goroutine), so it never blocks on a slow consumer. The queue is unbounded and warns on **delivery lag** — the age of the oldest undelivered event — rather than queue depth: depth is a poor proxy since per-event cost varies by orders of magnitude (a re-assert skip is tens of µs, a fresh attach is milliseconds), so the same depth can mean tens of ms or several seconds of lag. The age is checked at enqueue so a fully stalled consumer is still caught.

## Related Issue

Splits #9 into a reviewable stack; this is part 1 of 5.

## Checklist

- [x] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [x] I signed and signed-off the commits (`git commit -S -s ...`).
- [x] I have correctly attributed the author(s) of the code.
- [x] I have tested the changes locally.
- [x] I have followed the project's style guidelines.
- [x] I have updated the documentation, if necessary.
- [x] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

Unit tests (race-clean): per-subscriber FIFO delivery order, snapshot-then-live delivery, deltas-during-subscribe-follow-snapshot, unsubscribe-stops-delivery, source-runs-outside-lock / reentrancy, `RegisterSource` last-writer-wins, and delivery-lag warning (trips on a stalled head, quiet when not behind).

## Additional Notes

Stack (review in order): **1 pubsub** → 2 packetparser (#16) → 3 watchermanager (#17) → 4 apiserver/cache (#18) → 5 endpoint/netlink (#19). Rebased on latest `microsoft/main`.
