### PR TITLE
feat(packetparser): ifindex keying, liveness-checked idempotent attach, hardened teardown

### DIFF
--- a/pkg/plugin/ebpftest/helpers.go
+++ b/pkg/plugin/ebpftest/helpers.go
@@ -22,9 +22,9 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-// RequirePrivileged skips the test if the current process lacks BPF privileges.
-// It checks for CAP_BPF or CAP_SYS_ADMIN in the effective capability set.
-func RequirePrivileged(t *testing.T) {
+// RequirePrivileged skips the test/benchmark if the current process lacks BPF
+// privileges. It checks for CAP_BPF or CAP_SYS_ADMIN in the effective capability set.
+func RequirePrivileged(t testing.TB) {
 	t.Helper()
 
 	if os.Geteuid() == 0 {

--- a/pkg/plugin/packetparser/mocks/mock_types_linux.go
+++ b/pkg/plugin/packetparser/mocks/mock_types_linux.go
@@ -12,10 +12,63 @@ package mocks
 import (
 	reflect "reflect"
 
+	link "github.com/cilium/ebpf/link"
 	tc "github.com/florianl/go-tc"
 	netlink "github.com/mdlayher/netlink"
 	gomock "go.uber.org/mock/gomock"
 )
+
+// MocktcxLink is a mock of tcxLink interface.
+type MocktcxLink struct {
+	ctrl     *gomock.Controller
+	recorder *MocktcxLinkMockRecorder
+}
+
+// MocktcxLinkMockRecorder is the mock recorder for MocktcxLink.
+type MocktcxLinkMockRecorder struct {
+	mock *MocktcxLink
+}
+
+// NewMocktcxLink creates a new mock instance.
+func NewMocktcxLink(ctrl *gomock.Controller) *MocktcxLink {
+	mock := &MocktcxLink{ctrl: ctrl}
+	mock.recorder = &MocktcxLinkMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MocktcxLink) EXPECT() *MocktcxLinkMockRecorder {
+	return m.recorder
+}
+
+// Close mocks base method.
+func (m *MocktcxLink) Close() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Close")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Close indicates an expected call of Close.
+func (mr *MocktcxLinkMockRecorder) Close() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MocktcxLink)(nil).Close))
+}
+
+// Info mocks base method.
+func (m *MocktcxLink) Info() (*link.Info, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Info")
+	ret0, _ := ret[0].(*link.Info)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Info indicates an expected call of Info.
+func (mr *MocktcxLinkMockRecorder) Info() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Info", reflect.TypeOf((*MocktcxLink)(nil).Info))
+}
 
 // Mockqdisc is a mock of qdisc interface.
 type Mockqdisc struct {
@@ -103,6 +156,21 @@ func (m *Mockfilter) Add(info *tc.Object) error {
 func (mr *MockfilterMockRecorder) Add(info any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Add", reflect.TypeOf((*Mockfilter)(nil).Add), info)
+}
+
+// Get mocks base method.
+func (m *Mockfilter) Get(info *tc.Msg) ([]tc.Object, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Get", info)
+	ret0, _ := ret[0].([]tc.Object)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Get indicates an expected call of Get.
+func (mr *MockfilterMockRecorder) Get(info any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*Mockfilter)(nil).Get), info)
 }
 
 // Mocknltc is a mock of nltc interface.

--- a/pkg/plugin/packetparser/packetparser_ebpf_test.go
+++ b/pkg/plugin/packetparser/packetparser_ebpf_test.go
@@ -7,24 +7,29 @@ package packetparser
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"os"
 	"os/exec"
 	"path"
 	"runtime"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/link"
 	"github.com/cilium/ebpf/perf"
 	"github.com/cilium/ebpf/ringbuf"
+	tc "github.com/florianl/go-tc"
 	"github.com/gopacket/gopacket/layers"
 	"github.com/microsoft/retina/pkg/loader"
 	"github.com/microsoft/retina/pkg/log"
 	"github.com/microsoft/retina/pkg/plugin/ebpftest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/vishvananda/netlink"
 )
 
 const (
@@ -51,7 +56,7 @@ const (
 )
 
 // loadTestObjects loads the packetparser eBPF programs and maps for testing.
-func loadTestObjects(t *testing.T) (*packetparserObjects, *perf.Reader) {
+func loadTestObjects(t testing.TB) (*packetparserObjects, *perf.Reader) {
 	t.Helper()
 	ebpftest.RequirePrivileged(t)
 
@@ -1298,4 +1303,260 @@ func TestRingBufReaderWrapper(t *testing.T) {
 	// After closing, Read() should return ringbuf.ErrClosed
 	_, err = wrapper.Read()
 	assert.ErrorIs(t, err, ringbuf.ErrClosed)
+}
+
+// TestTCXLinkLivenessAcrossInterfaceDelete verifies the attachment liveness
+// probe against a real kernel: a TCX link on a live veth reports its interface
+// index, and reports Ifindex 0 (defunct) once the veth is deleted — the signal
+// createQdiscAndAttach uses to drop a stale attachment record and re-attach when
+// an interface index is reused. Requires kernel 6.6+ (TCX) and NET_ADMIN.
+func TestTCXLinkLivenessAcrossInterfaceDelete(t *testing.T) {
+	objs, _ := loadTestObjects(t)
+
+	la := netlink.NewLinkAttrs()
+	la.Name = "rtnlive0"
+	veth := &netlink.Veth{LinkAttrs: la, PeerName: "rtnlive0p"}
+	// Remove any leftover from a previously failed run.
+	if old, err := netlink.LinkByName(la.Name); err == nil {
+		_ = netlink.LinkDel(old)
+	}
+	require.NoError(t, netlink.LinkAdd(veth))
+	deleted := false
+	t.Cleanup(func() {
+		if !deleted {
+			_ = netlink.LinkDel(veth)
+		}
+	})
+
+	created, err := netlink.LinkByName(la.Name)
+	require.NoError(t, err)
+	idx := created.Attrs().Index
+
+	tcx, err := link.AttachTCX(link.TCXOptions{
+		Program:   objs.EndpointIngressFilter,
+		Attach:    ebpf.AttachTCXIngress,
+		Interface: idx,
+		Anchor:    link.Head(),
+	})
+	if errors.Is(err, ebpf.ErrNotSupported) {
+		t.Skipf("TCX not supported on this kernel: %v", err)
+	}
+	require.NoError(t, err)
+	t.Cleanup(func() { tcx.Close() })
+
+	// Alive: the probe sees the real interface index.
+	info, err := tcx.Info()
+	require.NoError(t, err)
+	tcxInfo := info.TCX()
+	require.NotNil(t, tcxInfo, "expected TCX metadata on a TCX link")
+	assert.Equal(t, uint32(idx), tcxInfo.Ifindex, "live link must report its interface index")
+	assert.True(t, tcxLinkAlive(tcx), "link on a live interface must probe alive")
+
+	// Delete the interface: the kernel auto-detaches, and the surviving link
+	// handle must probe defunct.
+	require.NoError(t, netlink.LinkDel(veth))
+	deleted = true
+
+	assert.Eventually(t, func() bool { return !tcxLinkAlive(tcx) },
+		2*time.Second, 10*time.Millisecond,
+		"link must probe dead after its interface is deleted")
+}
+
+// TestCreateQdiscAndAttachTC exercises the real legacy-TC path
+// (createQdiscAndAttach -> attachViaTC -> go-tc clsact qdisc + BPF filters) and
+// the real tcAttachmentAlive probe against a live kernel. Requires NET_ADMIN.
+func TestCreateQdiscAndAttachTC(t *testing.T) {
+	objs, _ := loadTestObjects(t)
+
+	// This binary (-tags=ebpf) also compiles the unit tests, which mutate these
+	// package-var seams to gomock fakes without restoring them. Reset them to the
+	// real implementations so this test drives the actual kernel, regardless of
+	// test execution order.
+	getQdisc = func(tcnl nltc) qdisc { return tcnl.Qdisc() }
+	getFilter = func(tcnl nltc) filter { return tcnl.Filter() }
+	tcOpen = func(config *tc.Config) (nltc, error) { return tc.Open(config) }
+	getFD = func(e *ebpf.Program) int { return e.FD() }
+
+	la := netlink.NewLinkAttrs()
+	la.Name = "rtntcatt"
+	veth := &netlink.Veth{LinkAttrs: la, PeerName: "rtntcattp"}
+	if old, err := netlink.LinkByName(la.Name); err == nil {
+		_ = netlink.LinkDel(old)
+	}
+	require.NoError(t, netlink.LinkAdd(veth))
+	deleted := false
+	t.Cleanup(func() {
+		if !deleted {
+			_ = netlink.LinkDel(veth)
+		}
+	})
+
+	created, err := netlink.LinkByName(la.Name)
+	require.NoError(t, err)
+	attrs := *created.Attrs()
+
+	p := &packetParser{
+		l:                   log.Logger().Named("test"),
+		objs:                objs,
+		attachmentMap:       &sync.Map{},
+		endpointIngressInfo: &ebpf.ProgramInfo{Name: "endpoint_ingress"},
+		endpointEgressInfo:  &ebpf.ProgramInfo{Name: "endpoint_egress"},
+		tcxSupported:        false, // force the legacy TC path
+	}
+	t.Cleanup(func() { _ = p.cleanAll() })
+
+	p.createQdiscAndAttach(attrs, Veth)
+
+	value, ok := p.attachmentMap.Load(ifaceToKey(attrs))
+	require.True(t, ok, "expected a recorded attachment after TC attach")
+	av := value.(*attachmentValue)
+	require.Equal(t, attachmentTypeTC, av.attachmentType, "should attach via legacy TC when TCX is disabled")
+	assert.True(t, p.attachmentAlive(av), "freshly attached clsact qdisc must probe alive")
+
+	// A re-assert while live must be a no-op (idempotent skip).
+	p.createQdiscAndAttach(attrs, Veth)
+	value2, _ := p.attachmentMap.Load(ifaceToKey(attrs))
+	assert.Same(t, av, value2.(*attachmentValue), "live re-assert must not re-attach")
+
+	// Delete the interface: the kernel removes the clsact qdisc, so the probe
+	// must report the attachment dead.
+	require.NoError(t, netlink.LinkDel(veth))
+	deleted = true
+	assert.Eventually(t, func() bool { return !p.attachmentAlive(av) },
+		2*time.Second, 10*time.Millisecond,
+		"attachment must probe dead after its interface (and clsact qdisc) is deleted")
+}
+
+// BenchmarkTCLivenessProbe measures the cost of a single legacy-TC liveness
+// probe (attachmentAlive -> a targeted per-ifindex filter query on the clsact
+// ingress hook) as the number of attached interfaces grows. Flat ns/op across N
+// shows the per-probe cost is O(1), keeping a full re-assert sweep over N
+// attachments at O(N) — a system-wide qdisc dump here would make the sweep
+// O(N^2). It is not run by CI (needs -bench and NET_ADMIN); run on a privileged
+// host with:
+//
+//	go test -tags=ebpf -run='^$' -bench=BenchmarkTCLivenessProbe ./pkg/plugin/packetparser/
+//
+// TCX's probe is one per-link Info() syscall, also O(1) (see its benchmark).
+func BenchmarkTCLivenessProbe(b *testing.B) {
+	objs, _ := loadTestObjects(b)
+
+	// -tags=ebpf also compiles the mock-mutating unit tests; use the real impls.
+	getQdisc = func(tcnl nltc) qdisc { return tcnl.Qdisc() }
+	getFilter = func(tcnl nltc) filter { return tcnl.Filter() }
+	tcOpen = func(config *tc.Config) (nltc, error) { return tc.Open(config) }
+	getFD = func(e *ebpf.Program) int { return e.FD() }
+
+	for _, n := range []int{50, 100, 200} {
+		b.Run(fmt.Sprintf("N=%d", n), func(b *testing.B) {
+			p := &packetParser{
+				l:                   log.Logger().Named("bench"),
+				objs:                objs,
+				attachmentMap:       &sync.Map{},
+				endpointIngressInfo: &ebpf.ProgramInfo{Name: "endpoint_ingress"},
+				endpointEgressInfo:  &ebpf.ProgramInfo{Name: "endpoint_egress"},
+				tcxSupported:        false, // force legacy TC
+			}
+			var veths []*netlink.Veth
+			b.Cleanup(func() {
+				_ = p.cleanAll()
+				for _, v := range veths {
+					_ = netlink.LinkDel(v)
+				}
+			})
+
+			// Setup (untimed): create and attach N veths via the real TC path.
+			var probeKey attachmentKey
+			for i := 0; i < n; i++ {
+				la := netlink.NewLinkAttrs()
+				la.Name = fmt.Sprintf("rtnbench%d", i)
+				veth := &netlink.Veth{LinkAttrs: la, PeerName: fmt.Sprintf("rtnbenchp%d", i)}
+				if old, err := netlink.LinkByName(la.Name); err == nil {
+					_ = netlink.LinkDel(old)
+				}
+				require.NoError(b, netlink.LinkAdd(veth))
+				veths = append(veths, veth)
+				created, err := netlink.LinkByName(la.Name)
+				require.NoError(b, err)
+				attrs := *created.Attrs()
+				p.createQdiscAndAttach(attrs, Veth)
+				probeKey = ifaceToKey(attrs)
+			}
+			val, ok := p.attachmentMap.Load(probeKey)
+			require.True(b, ok, "expected an attachment to probe")
+			av := val.(*attachmentValue)
+
+			// Timed: one liveness probe per iteration. b.Loop keeps the setup
+			// above out of the measured region and runs it only once.
+			for b.Loop() {
+				if !p.attachmentAlive(av) {
+					b.Fatal("attachment should probe alive")
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkTCXLivenessProbe is the TCX counterpart of BenchmarkTCLivenessProbe.
+// A TCX probe is a single per-link Info() syscall, so ns/op should stay flat as
+// N grows. Both transports now probe O(1); TCX remains cheaper (no netlink
+// round-trips). Requires kernel 6.6+ (TCX) and NET_ADMIN.
+// Run alongside the TC benchmark:
+//
+//	go test -tags=ebpf -run='^$' -bench='BenchmarkTC.*LivenessProbe' ./pkg/plugin/packetparser/
+func BenchmarkTCXLivenessProbe(b *testing.B) {
+	objs, _ := loadTestObjects(b)
+	if !isTCXSupported() {
+		b.Skip("TCX not supported on this kernel")
+	}
+	// The TCX path uses link.AttachTCX directly and none of the mutable TC seams,
+	// so no reset is needed here.
+
+	for _, n := range []int{50, 100, 200} {
+		b.Run(fmt.Sprintf("N=%d", n), func(b *testing.B) {
+			p := &packetParser{
+				l:                   log.Logger().Named("bench"),
+				objs:                objs,
+				attachmentMap:       &sync.Map{},
+				endpointIngressInfo: &ebpf.ProgramInfo{Name: "endpoint_ingress"},
+				endpointEgressInfo:  &ebpf.ProgramInfo{Name: "endpoint_egress"},
+				tcxSupported:        true, // force TCX
+			}
+			var veths []*netlink.Veth
+			b.Cleanup(func() {
+				_ = p.cleanAll()
+				for _, v := range veths {
+					_ = netlink.LinkDel(v)
+				}
+			})
+
+			// Setup (untimed): create and attach N veths via the real TCX path.
+			var probeKey attachmentKey
+			for i := 0; i < n; i++ {
+				la := netlink.NewLinkAttrs()
+				la.Name = fmt.Sprintf("rtnxbench%d", i)
+				veth := &netlink.Veth{LinkAttrs: la, PeerName: fmt.Sprintf("rtnxbenchp%d", i)}
+				if old, err := netlink.LinkByName(la.Name); err == nil {
+					_ = netlink.LinkDel(old)
+				}
+				require.NoError(b, netlink.LinkAdd(veth))
+				veths = append(veths, veth)
+				created, err := netlink.LinkByName(la.Name)
+				require.NoError(b, err)
+				attrs := *created.Attrs()
+				p.createQdiscAndAttach(attrs, Veth)
+				probeKey = ifaceToKey(attrs)
+			}
+			val, ok := p.attachmentMap.Load(probeKey)
+			require.True(b, ok, "expected an attachment to probe")
+			av := val.(*attachmentValue)
+			require.Equal(b, attachmentTypeTCX, av.attachmentType, "setup must use the TCX path")
+
+			for b.Loop() {
+				if !p.attachmentAlive(av) {
+					b.Fatal("attachment should probe alive")
+				}
+			}
+		})
+	}
 }

--- a/pkg/plugin/packetparser/packetparser_linux.go
+++ b/pkg/plugin/packetparser/packetparser_linux.go
@@ -343,6 +343,7 @@ func (p *packetParser) Start(ctx context.Context) error {
 	}
 
 	p.l.Info("Starting packet parser")
+	p.stopping.Store(false) // may be set from a prior Stop on this instance
 
 	p.l.Info("setting up enricher since pod level is enabled")
 	// Set up enricher.
@@ -398,6 +399,23 @@ func (p *packetParser) Stop() error {
 	// Get pubsubs instance
 	ps := pubsub.New()
 
+	// Quiesce the endpoint callback FIRST: mark stopping (deliveries become
+	// no-ops), unsubscribe, then wait out any delivery already in flight —
+	// pubsub's Unsubscribe does not wait for one. Only then is it safe to close
+	// programs and clean attachments; tearing down first would let an in-flight
+	// attach use closed programs or Store after cleanAll, leaking a live link.
+	p.stopping.Store(true)
+	if p.callbackID != "" {
+		if err := ps.Unsubscribe(common.PubSubEndpoints, p.callbackID); err != nil {
+			p.l.Error("Error unregistering callback for packetParser", zap.Error(err))
+		}
+		// Reset callback ID.
+		p.callbackID = ""
+	}
+	p.cbMu.Lock()
+	p.cbMu.Unlock() //nolint:staticcheck,gocritic // empty critical section is the point: a barrier for an in-flight callback
+	p.l.Debug("Quiesced endpoint callback")
+
 	// Stop perf reader.
 	if p.reader != nil {
 		if err := p.reader.Close(); err != nil {
@@ -421,15 +439,6 @@ func (p *packetParser) Stop() error {
 	}
 	p.l.Debug("Stopped map/progs")
 
-	// Unregister callback.
-	if p.callbackID != "" {
-		if err := ps.Unsubscribe(common.PubSubEndpoints, p.callbackID); err != nil {
-			p.l.Error("Error unregistering callback for packetParser", zap.Error(err))
-		}
-		// Reset callback ID.
-		p.callbackID = ""
-	}
-
 	if err := p.cleanAll(); err != nil {
 		p.l.Error("Error cleaning", zap.Error(err))
 		return err
@@ -446,6 +455,10 @@ func (p *packetParser) SetupChannel(ch chan *v1.Event) error {
 
 // cleanAll is NOT thread safe.
 // Not required for now.
+// Accepted gap (legacy TC only): the qdisc delete is unconditional, so if an
+// attach rode on a clsact another agent created (ErrExist-tolerated), stopping
+// Retina removes that agent's filters too. TCX teardown closes only our own
+// links.
 func (p *packetParser) cleanAll() error {
 	if p.attachmentMap == nil {
 		return nil
@@ -473,7 +486,7 @@ func (p *packetParser) clean(rtnl nltc, qdisc *tc.Object) {
 	// Warning, not error. Clean is best effort.
 	if rtnl != nil {
 		if err := getQdisc(rtnl).Delete(qdisc); err != nil && !errors.Is(err, tc.ErrNoArg) {
-			p.l.Debug("could not delete egress qdisc", zap.Error(err))
+			p.l.Debug("could not delete clsact qdisc", zap.Error(err))
 		}
 		if err := rtnl.Close(); err != nil {
 			p.l.Warn("could not close rtnetlink socket", zap.Error(err))
@@ -481,8 +494,85 @@ func (p *packetParser) clean(rtnl nltc, qdisc *tc.Object) {
 	}
 }
 
+// attachmentAlive reports whether a recorded attachment still exists in the
+// kernel. Both transports are probed at the same granularity (interface-level):
+// TCX via the link's Ifindex, legacy TC via the presence of a bpf filter on
+// the clsact ingress hook.
+// The kernel tears both down when the interface is deleted, so a probe that
+// comes back dead means the record is stale (interface gone, possibly with its
+// index already reused) and must be re-attached.
+func (p *packetParser) attachmentAlive(v *attachmentValue) bool {
+	if v.attachmentType == attachmentTypeTCX {
+		return tcxLinkAlive(v.tcxIngressLink) && tcxLinkAlive(v.tcxEgressLink)
+	}
+	return p.tcAttachmentAlive(v)
+}
+
+// tcAttachmentAlive reports whether a BPF filter still exists on the recorded
+// interface's clsact ingress hook. It queries only that interface+parent (O(1)),
+// rather than dumping every qdisc system-wide, so a re-assert sweep over N
+// attachments stays O(N) instead of O(N^2). The kernel removes the clsact qdisc
+// and its filters when the interface is deleted, so the filter's absence means
+// the attachment is defunct. A probe error (e.g. the socket is unusable) is
+// treated as dead so we re-attach rather than trust a stale record.
+//
+// The probe matches on presence (any bpf filter), deliberately no stronger:
+// the repair path is an EEXIST-tolerant Add, which can only fix "no filter
+// there" — a probe that detects more than Add can repair (e.g. matching our
+// program ID) turns unrepairable states into per-refresh re-attach churn that
+// accumulates duplicate auto-handle filters. Accepted, documented gaps of the
+// legacy-TC fallback, all absent under TCX:
+//   - unclean agent restart: the surviving filters satisfy the probe; the
+//     first re-attach leaves one duplicate ingress filter and the egress hook
+//     keeps the dead process's program until the veth churns.
+//   - index reuse where the new occupant carries another agent's bpf filter:
+//     probes false-alive, so that veth stays unmonitored until it churns.
+//   - another legacy-TC agent on the same hooks contends for the conventional
+//     (prio 1) slots.
+func (p *packetParser) tcAttachmentAlive(v *attachmentValue) bool {
+	if v.tc == nil || v.qdisc == nil {
+		return false
+	}
+	filters, err := getFilter(v.tc).Get(&tc.Msg{
+		Family:  unix.AF_UNSPEC,
+		Ifindex: v.qdisc.Ifindex,
+		Parent:  helper.BuildHandle(0xFFFF, tc.HandleMinIngress), //nolint:gomnd // clsact ingress parent, matches attachViaTC
+	})
+	if err != nil {
+		p.l.Debug("could not query filters for TC liveness probe", zap.Error(err))
+		return false
+	}
+	for i := range filters {
+		if filters[i].Kind == "bpf" {
+			return true
+		}
+	}
+	return false
+}
+
+// tcxLinkAlive reports whether a TCX link is still attached to a live
+// interface. The kernel auto-detaches TCX links when their interface is
+// deleted; the surviving defunct link reports Ifindex 0.
+func tcxLinkAlive(l tcxLink) bool {
+	if l == nil {
+		return false
+	}
+	info, err := l.Info()
+	if err != nil {
+		return false
+	}
+	return tcxInfoAlive(info.TCX())
+}
+
+// tcxInfoAlive is the liveness decision on a link's TCX metadata: Ifindex 0
+// means the kernel cleared the device (interface deleted). Nil metadata means
+// liveness cannot be determined; treat as alive rather than churn attachments.
+func tcxInfoAlive(tcx *link.TCXInfo) bool {
+	return tcx == nil || tcx.Ifindex != 0
+}
+
 // cleanTCX closes TCX links. This is best effort.
-func (p *packetParser) cleanTCX(ingressLink, egressLink link.Link) {
+func (p *packetParser) cleanTCX(ingressLink, egressLink tcxLink) {
 	if ingressLink != nil {
 		if err := ingressLink.Close(); err != nil {
 			p.l.Debug("could not close ingress TCX link", zap.Error(err))
@@ -531,6 +621,15 @@ func isTCXSupported() bool {
 }
 
 func (p *packetParser) endpointWatcherCallbackFn(obj interface{}) {
+	// Serialize with Stop: a delivery already in flight when Stop unsubscribes
+	// must finish (or become a no-op) before Stop tears down programs and maps,
+	// otherwise a racing attach can Store after cleanAll and leak a live link.
+	p.cbMu.Lock()
+	defer p.cbMu.Unlock()
+	if p.stopping.Load() {
+		return
+	}
+
 	// Contract is that we will receive an endpoint event pointer.
 	event := obj.(*endpoint.EndpointEvent)
 	if event == nil {
@@ -556,8 +655,15 @@ func (p *packetParser) endpointWatcherCallbackFn(obj interface{}) {
 			v := value.(*attachmentValue)
 			if v.attachmentType == attachmentTypeTCX {
 				p.cleanTCX(v.tcxIngressLink, v.tcxEgressLink)
-			} else {
-				p.clean(v.tc, v.qdisc)
+			} else if v.tc != nil {
+				// Close only the socket — do NOT delete the qdisc. A delete event
+				// means the interface is gone (the kernel already destroyed our
+				// qdisc) or its index was reused (the watcher's reuse detection
+				// publishes a delete for a live index): a clsact present at this
+				// ifindex belongs to the new occupant, possibly another agent.
+				if err := v.tc.Close(); err != nil {
+					p.l.Warn("could not close rtnetlink socket", zap.Error(err))
+				}
 			}
 			// Delete from map.
 			p.attachmentMap.Delete(ifaceKey)
@@ -574,6 +680,35 @@ func (p *packetParser) endpointWatcherCallbackFn(obj interface{}) {
 // depending on kernel support and configuration.
 // Only support interfaces of type veth and device.
 func (p *packetParser) createQdiscAndAttach(iface netlink.LinkAttrs, ifaceType interfaceType) {
+	// Idempotent: skip if already attached so repeated reconcile events don't
+	// double-attach and leak links. Presence alone isn't enough: verify the
+	// recorded attachment is still live in the kernel. A record can outlive its
+	// attachment — the interface was deleted and its index reused before we saw
+	// the delete, or the programs were detached externally — and trusting it
+	// would leave the current occupant unmonitored until it next churns. The
+	// level-triggered re-assert redelivers creates every refresh, so dropping a
+	// stale record here self-heals within one refresh interval.
+	if value, ok := p.attachmentMap.Load(ifaceToKey(iface)); ok {
+		v := value.(*attachmentValue)
+		if p.attachmentAlive(v) {
+			return
+		}
+		p.l.Warn("stale attachment record; re-attaching",
+			zap.String("interface", iface.Name), zap.Int("index", iface.Index))
+		// Best effort: release the defunct handles before re-attaching so we don't
+		// leak the TCX links or the TC rtnetlink socket. For TC, close only the
+		// socket — do NOT delete the qdisc: on index reuse the clsact at this
+		// ifindex may belong to the interface's new occupant (another agent), and
+		// attachViaTC tolerates an existing qdisc anyway.
+		if v.attachmentType == attachmentTypeTCX {
+			p.cleanTCX(v.tcxIngressLink, v.tcxEgressLink)
+		} else if v.tc != nil {
+			if err := v.tc.Close(); err != nil {
+				p.l.Warn("could not close stale rtnetlink socket", zap.Error(err))
+			}
+		}
+		p.attachmentMap.Delete(ifaceToKey(iface))
+	}
 	p.l.Debug("Starting attachment", zap.String("interface", iface.Name))
 
 	if p.tcxSupported {
@@ -644,7 +779,6 @@ func (p *packetParser) attachViaTC(iface netlink.LinkAttrs, ifaceType interfaceT
 	var (
 		ingressProgram, egressProgram *ebpf.Program
 		ingressInfo, egressInfo       *ebpf.ProgramInfo
-		err                           error
 	)
 
 	switch ifaceType {
@@ -670,8 +804,10 @@ func (p *packetParser) attachViaTC(iface netlink.LinkAttrs, ifaceType interfaceT
 		return
 	}
 	// set extended acknowledge option for more detailed error messages.
-	if err = rtnl.SetOption(nl.ExtendedAcknowledge, true); err != nil {
-		p.l.Warn("could not set extended acknowledge option", zap.Error(err))
+	// Non-fatal: must not feed the cleanup defer below (a poisoned err would tear
+	// down a successful attach), so keep its error local.
+	if optErr := rtnl.SetOption(nl.ExtendedAcknowledge, true); optErr != nil {
+		p.l.Warn("could not set extended acknowledge option", zap.Error(optErr))
 	}
 
 	// Create a qdisc of type clsact on the tunnel interface.
@@ -690,13 +826,32 @@ func (p *packetParser) attachViaTC(iface netlink.LinkAttrs, ifaceType interfaceT
 			Kind: "clsact",
 		},
 	}
+	// Release the socket and undo the qdisc on any failed exit. Keyed on explicit
+	// flags, not err: the failure returns below shadow err, so an err-keyed defer
+	// would never fire — leaking one rtnl fd per failed attach, once per refresh
+	// under the level-triggered re-assert. Delete only a qdisc we created — a
+	// pre-existing clsact may belong to another agent, and deleting it would tear
+	// down their filters too.
+	attached := false
+	createdQdisc := false
 	defer func() {
-		if err != nil {
-			p.clean(rtnl, clsactQdisc)
+		if attached {
+			return
+		}
+		if createdQdisc {
+			if err := getQdisc(rtnl).Delete(clsactQdisc); err != nil && !errors.Is(err, tc.ErrNoArg) {
+				p.l.Debug("could not delete clsact qdisc", zap.Error(err))
+			}
+		}
+		if err := rtnl.Close(); err != nil {
+			p.l.Warn("could not close rtnetlink socket", zap.Error(err))
 		}
 	}()
 	// Install Qdisc on interface.
-	if err := getQdisc(rtnl).Add(clsactQdisc); err != nil && !errors.Is(err, os.ErrExist) {
+	switch err := getQdisc(rtnl).Add(clsactQdisc); {
+	case err == nil:
+		createdQdisc = true
+	case !errors.Is(err, os.ErrExist):
 		p.l.Error("could not assign clsact to tunnel interface", zap.String("interface", iface.Name), zap.Error(err))
 		return
 	}
@@ -752,6 +907,7 @@ func (p *packetParser) attachViaTC(iface netlink.LinkAttrs, ifaceType interfaceT
 		tc:             rtnl,
 		qdisc:          clsactQdisc,
 	})
+	attached = true
 
 	p.l.Debug("Successfully attached BPF programs using traditional TC", zap.String("interface", iface.Name))
 }

--- a/pkg/plugin/packetparser/packetparser_linux_test.go
+++ b/pkg/plugin/packetparser/packetparser_linux_test.go
@@ -18,6 +18,7 @@ import (
 
 	v1 "github.com/cilium/cilium/pkg/hubble/api/v1"
 	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/link"
 	"github.com/cilium/ebpf/ringbuf"
 	tc "github.com/florianl/go-tc"
 	nl "github.com/mdlayher/netlink"
@@ -79,6 +80,8 @@ func (mr *mockPerfReaderRecorder) Close() *gomock.Call {
 
 var errTestRead = errors.New("error")
 
+var errLinkDefunct = errors.New("link is defunct")
+
 var (
 	cfgPodLevelEnabled = &kcfg.Config{
 		EnablePodLevel:           true,
@@ -136,8 +139,8 @@ func TestCleanAll(t *testing.T) {
 		return mq
 	}
 
-	p.attachmentMap.Store(attachmentKey{"test", "test", 1}, &attachmentValue{tc: mrtnl, qdisc: &tc.Object{}})
-	p.attachmentMap.Store(attachmentKey{"test2", "test2", 2}, &attachmentValue{tc: mrtnl, qdisc: &tc.Object{}})
+	p.attachmentMap.Store(attachmentKey{1}, &attachmentValue{tc: mrtnl, qdisc: &tc.Object{}})
+	p.attachmentMap.Store(attachmentKey{2}, &attachmentValue{tc: mrtnl, qdisc: &tc.Object{}})
 
 	assert.Nil(t, p.cleanAll())
 
@@ -182,7 +185,7 @@ func TestClean(t *testing.T) {
 }
 
 func TestCleanWithErrors(t *testing.T) {
-	log.SetupZapLogger(log.GetDefaultLogOpts())
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
 
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -209,7 +212,7 @@ func TestCleanWithErrors(t *testing.T) {
 }
 
 func TestEndpointWatcherCallbackFn_EndpointDeleted(t *testing.T) {
-	log.SetupZapLogger(log.GetDefaultLogOpts())
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -229,9 +232,18 @@ func TestEndpointWatcherCallbackFn_EndpointDeleted(t *testing.T) {
 	}
 	key := ifaceToKey(linkAttr)
 
+	// The delete path must close only the stale socket — never delete the qdisc:
+	// a delete event means the interface is gone or its index was reused, so a
+	// clsact at this ifindex may belong to the new occupant. A strict qdisc mock
+	// with no expectations turns any Delete into a test failure.
+	mq := mocks.NewMockqdisc(ctrl)
+	getQdisc = func(nltc) qdisc { return mq }
+	oldRtnl := mocks.NewMocknltc(ctrl)
+	oldRtnl.EXPECT().Close().Return(nil).Times(1)
+
 	// Pre-populate both maps to simulate existing interface
 	p.interfaceLockMap.Store(key, &sync.Mutex{})
-	p.attachmentMap.Store(key, &attachmentValue{tc: nil, qdisc: &tc.Object{}})
+	p.attachmentMap.Store(key, &attachmentValue{tc: oldRtnl, qdisc: &tc.Object{}})
 
 	// Create EndpointDeleted event.
 	e := &endpoint.EndpointEvent{
@@ -251,7 +263,7 @@ func TestEndpointWatcherCallbackFn_EndpointDeleted(t *testing.T) {
 }
 
 func TestCreateQdiscAndAttach(t *testing.T) {
-	log.SetupZapLogger(log.GetDefaultLogOpts())
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -281,7 +293,7 @@ func TestCreateQdiscAndAttach(t *testing.T) {
 		return 1
 	}
 
-	pObj := &packetparserObjects{} //nolint:typecheck
+	pObj := &packetparserObjects{} //nolint:typecheck // generated bpf2go type
 	pObj.EndpointIngressFilter = &ebpf.Program{}
 	pObj.EndpointEgressFilter = &ebpf.Program{}
 
@@ -308,6 +320,7 @@ func TestCreateQdiscAndAttach(t *testing.T) {
 		Name:         "test",
 		HardwareAddr: []byte("test"),
 		NetNsID:      1,
+		Index:        1,
 	}
 	// Test veth.
 	p.createQdiscAndAttach(linkAttr, Veth)
@@ -322,6 +335,7 @@ func TestCreateQdiscAndAttach(t *testing.T) {
 		Name:         "test2",
 		HardwareAddr: []byte("test2"),
 		NetNsID:      2,
+		Index:        2,
 	}
 	// Test Device.
 	p.createQdiscAndAttach(linkAttr2, Device)
@@ -331,8 +345,434 @@ func TestCreateQdiscAndAttach(t *testing.T) {
 	assert.True(t, ok)
 }
 
+// fakeTCXLink fakes a stored TCX link for the liveness check.
+type fakeTCXLink struct {
+	info   *link.Info
+	err    error
+	closed bool
+}
+
+func (f *fakeTCXLink) Info() (*link.Info, error) { return f.info, f.err }
+func (f *fakeTCXLink) Close() error              { f.closed = true; return nil }
+
+func TestTCXInfoAlive(t *testing.T) {
+	assert.True(t, tcxInfoAlive(nil), "indeterminate metadata must not churn attachments")
+	assert.True(t, tcxInfoAlive(&link.TCXInfo{Ifindex: 42}), "non-zero ifindex is a live attachment")
+	assert.False(t, tcxInfoAlive(&link.TCXInfo{Ifindex: 0}), "ifindex 0 marks a defunct link (interface deleted)")
+}
+
+// A live recorded attachment must short-circuit the re-assert: no re-attach, the
+// stored value untouched.
+func TestCreateQdiscAndAttachSkipsLiveAttachment(t *testing.T) {
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
+
+	linkAttr := netlink.LinkAttrs{Name: "live", Index: 100}
+	seeded := &attachmentValue{
+		attachmentType: attachmentTypeTCX,
+		tcxIngressLink: &fakeTCXLink{info: &link.Info{}}, // no TCX metadata -> treated alive
+		tcxEgressLink:  &fakeTCXLink{info: &link.Info{}},
+	}
+
+	p := &packetParser{
+		l:             log.Logger().Named("test"),
+		attachmentMap: &sync.Map{},
+	}
+	p.attachmentMap.Store(ifaceToKey(linkAttr), seeded)
+
+	p.createQdiscAndAttach(linkAttr, Veth)
+
+	got, ok := p.attachmentMap.Load(ifaceToKey(linkAttr))
+	assert.True(t, ok)
+	assert.Same(t, seeded, got.(*attachmentValue), "live attachment must be left untouched")
+}
+
+// A stale record (links dead in the kernel: interface deleted with its index
+// reused, or programs detached externally) must be dropped and the interface
+// re-attached, so the level-triggered re-assert self-heals it.
+func TestCreateQdiscAndAttachReplacesStaleAttachment(t *testing.T) {
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mfilter := mocks.NewMockfilter(ctrl)
+	mfilter.EXPECT().Add(gomock.Any()).Return(nil).AnyTimes()
+	mq := mocks.NewMockqdisc(ctrl)
+	mq.EXPECT().Add(gomock.Any()).Return(nil).AnyTimes()
+	mrtnl := mocks.NewMocknltc(ctrl)
+	mrtnl.EXPECT().Qdisc().Return(nil).AnyTimes()
+	mrtnl.EXPECT().SetOption(nl.ExtendedAcknowledge, true).Return(nil).AnyTimes()
+	getQdisc = func(nltc) qdisc { return mq }
+	getFilter = func(nltc) filter { return mfilter }
+	tcOpen = func(*tc.Config) (nltc, error) { return mrtnl, nil }
+	getFD = func(_ *ebpf.Program) int { return 1 }
+
+	pObj := &packetparserObjects{} //nolint:typecheck // generated bpf2go type
+	pObj.EndpointIngressFilter = &ebpf.Program{}
+	pObj.EndpointEgressFilter = &ebpf.Program{}
+
+	linkAttr := netlink.LinkAttrs{Name: "stale", Index: 200}
+	deadIngress := &fakeTCXLink{err: errLinkDefunct}
+	deadEgress := &fakeTCXLink{err: errLinkDefunct}
+	seeded := &attachmentValue{
+		attachmentType: attachmentTypeTCX,
+		tcxIngressLink: deadIngress,
+		tcxEgressLink:  deadEgress,
+	}
+
+	p := &packetParser{
+		cfg:                 cfgPodLevelEnabled,
+		l:                   log.Logger().Named("test"),
+		objs:                pObj,
+		interfaceLockMap:    &sync.Map{},
+		endpointIngressInfo: &ebpf.ProgramInfo{Name: "ingress"},
+		endpointEgressInfo:  &ebpf.ProgramInfo{Name: "egress"},
+		attachmentMap:       &sync.Map{},
+	}
+	p.attachmentMap.Store(ifaceToKey(linkAttr), seeded)
+
+	p.createQdiscAndAttach(linkAttr, Veth)
+
+	got, ok := p.attachmentMap.Load(ifaceToKey(linkAttr))
+	assert.True(t, ok, "interface must be re-attached after the stale record is dropped")
+	assert.NotSame(t, seeded, got.(*attachmentValue), "stale record must be replaced by a fresh attachment")
+	assert.True(t, deadIngress.closed && deadEgress.closed, "stale link handles must be closed")
+}
+
+// A live legacy-TC attachment (a bpf filter still present on the interface's
+// ingress hook) must be left untouched on re-assert — no re-attach, no churn.
+func TestCreateQdiscAndAttachSkipsLiveTCAttachment(t *testing.T) {
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	const idx = 300
+	mfilter := mocks.NewMockfilter(ctrl)
+	mfilter.EXPECT().Get(gomock.Any()).Return([]tc.Object{
+		{Attribute: tc.Attribute{Kind: "bpf"}},
+	}, nil).Times(1)
+	getFilter = func(nltc) filter { return mfilter }
+
+	linkAttr := netlink.LinkAttrs{Name: "tc-live", Index: idx}
+	seeded := &attachmentValue{
+		attachmentType: attachmentTypeTC,
+		tc:             mocks.NewMocknltc(ctrl),
+		qdisc:          &tc.Object{Msg: tc.Msg{Ifindex: idx}},
+	}
+
+	p := &packetParser{
+		l:             log.Logger().Named("test"),
+		attachmentMap: &sync.Map{},
+	}
+	p.attachmentMap.Store(ifaceToKey(linkAttr), seeded)
+
+	p.createQdiscAndAttach(linkAttr, Veth)
+
+	got, ok := p.attachmentMap.Load(ifaceToKey(linkAttr))
+	assert.True(t, ok)
+	assert.Same(t, seeded, got.(*attachmentValue), "live TC attachment must be left untouched")
+}
+
+// A dead legacy-TC attachment (no bpf filter — interface deleted, possibly
+// index reused — or an unusable probe socket) must be re-attached and the stale
+// rtnetlink socket released — WITHOUT deleting the clsact qdisc, which on index
+// reuse may belong to the interface's new occupant (no mq.Delete expectation:
+// any Delete call fails the test).
+func TestCreateQdiscAndAttachReplacesDeadTCAttachment(t *testing.T) {
+	cases := []struct {
+		name  string
+		probe func(msg *tc.Msg) ([]tc.Object, error)
+	}{
+		{"no filters", func(*tc.Msg) ([]tc.Object, error) { return nil, nil }},
+		{"probe error", func(*tc.Msg) ([]tc.Object, error) { return nil, errTestRead }},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			const idx = 302
+			mq := mocks.NewMockqdisc(ctrl)
+			// Add is the re-attach. No Delete expectation: the dead path must not
+			// delete a qdisc it cannot prove is ours.
+			mq.EXPECT().Add(gomock.Any()).Return(nil).Times(1)
+			getQdisc = func(nltc) qdisc { return mq }
+
+			mfilter := mocks.NewMockfilter(ctrl)
+			mfilter.EXPECT().Get(gomock.Any()).DoAndReturn(tt.probe).Times(1)
+			mfilter.EXPECT().Add(gomock.Any()).Return(nil).Times(2)
+			getFilter = func(nltc) filter { return mfilter }
+			getFD = func(_ *ebpf.Program) int { return 1 }
+
+			newRtnl := mocks.NewMocknltc(ctrl)
+			newRtnl.EXPECT().SetOption(nl.ExtendedAcknowledge, true).Return(nil).Times(1)
+			tcOpen = func(*tc.Config) (nltc, error) { return newRtnl, nil }
+
+			// The stale attachment's socket must be closed when we drop it.
+			oldRtnl := mocks.NewMocknltc(ctrl)
+			oldRtnl.EXPECT().Close().Return(nil).Times(1)
+
+			pObj := &packetparserObjects{} //nolint:typecheck // generated bpf2go type
+			pObj.EndpointIngressFilter = &ebpf.Program{}
+			pObj.EndpointEgressFilter = &ebpf.Program{}
+
+			linkAttr := netlink.LinkAttrs{Name: "tc-dead", Index: idx}
+			seeded := &attachmentValue{
+				attachmentType: attachmentTypeTC,
+				tc:             oldRtnl,
+				qdisc:          &tc.Object{Msg: tc.Msg{Ifindex: idx}},
+			}
+
+			p := &packetParser{
+				cfg:                 cfgPodLevelEnabled,
+				l:                   log.Logger().Named("test"),
+				objs:                pObj,
+				interfaceLockMap:    &sync.Map{},
+				endpointIngressInfo: &ebpf.ProgramInfo{Name: "ingress"},
+				endpointEgressInfo:  &ebpf.ProgramInfo{Name: "egress"},
+				attachmentMap:       &sync.Map{},
+			}
+			p.attachmentMap.Store(ifaceToKey(linkAttr), seeded)
+
+			p.createQdiscAndAttach(linkAttr, Veth)
+
+			got, ok := p.attachmentMap.Load(ifaceToKey(linkAttr))
+			assert.True(t, ok, "interface must be re-attached after the dead record is dropped")
+			assert.NotSame(t, seeded, got.(*attachmentValue), "dead record must be replaced by a fresh attachment")
+		})
+	}
+}
+
+// A non-fatal SetOption failure must not poison the cleanup path: the attach
+// still succeeds and must NOT be torn down afterwards (no qdisc Delete, no
+// socket Close — either call fails the test via missing expectations).
+func TestAttachViaTCSurvivesSetOptionFailure(t *testing.T) {
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mq := mocks.NewMockqdisc(ctrl)
+	mq.EXPECT().Add(gomock.Any()).Return(nil).Times(1)
+	getQdisc = func(nltc) qdisc { return mq }
+
+	mfilter := mocks.NewMockfilter(ctrl)
+	mfilter.EXPECT().Add(gomock.Any()).Return(nil).Times(2)
+	getFilter = func(nltc) filter { return mfilter }
+	getFD = func(_ *ebpf.Program) int { return 1 }
+
+	mrtnl := mocks.NewMocknltc(ctrl)
+	mrtnl.EXPECT().SetOption(nl.ExtendedAcknowledge, true).Return(errTestRead).Times(1)
+	tcOpen = func(*tc.Config) (nltc, error) { return mrtnl, nil }
+
+	pObj := &packetparserObjects{} //nolint:typecheck // generated bpf2go type
+	pObj.EndpointIngressFilter = &ebpf.Program{}
+	pObj.EndpointEgressFilter = &ebpf.Program{}
+
+	p := &packetParser{
+		cfg:                 cfgPodLevelEnabled,
+		l:                   log.Logger().Named("test"),
+		objs:                pObj,
+		endpointIngressInfo: &ebpf.ProgramInfo{Name: "ingress"},
+		endpointEgressInfo:  &ebpf.ProgramInfo{Name: "egress"},
+		attachmentMap:       &sync.Map{},
+	}
+
+	linkAttr := netlink.LinkAttrs{Name: "tc-optfail", Index: 310}
+	p.attachViaTC(linkAttr, Veth)
+
+	_, ok := p.attachmentMap.Load(ifaceToKey(linkAttr))
+	assert.True(t, ok, "attach must survive a non-fatal SetOption failure")
+}
+
+// A failed attach must release the rtnetlink socket — the failure returns
+// shadow err, so a defer keyed on err instead of an explicit flag never runs,
+// leaking one fd per failed attach, once per refresh under the re-assert. The
+// clsact qdisc is undone only if we created it: a pre-existing one may belong
+// to another agent (no Delete expectation in that case — a Delete call fails
+// the test).
+func TestAttachViaTCReleasesSocketOnFailedAttach(t *testing.T) {
+	cases := []struct {
+		name        string
+		qdiscAddErr error
+		wantDelete  bool
+	}{
+		{"qdisc created by us", nil, true},
+		{"qdisc pre-existing (possibly another agent's)", os.ErrExist, false},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mq := mocks.NewMockqdisc(ctrl)
+			mq.EXPECT().Add(gomock.Any()).Return(tt.qdiscAddErr).Times(1)
+			if tt.wantDelete {
+				mq.EXPECT().Delete(gomock.Any()).Return(nil).Times(1) // undo our own qdisc
+			}
+			getQdisc = func(nltc) qdisc { return mq }
+
+			mfilter := mocks.NewMockfilter(ctrl)
+			mfilter.EXPECT().Add(gomock.Any()).Return(errTestRead).Times(1) // ingress add fails
+			getFilter = func(nltc) filter { return mfilter }
+			getFD = func(_ *ebpf.Program) int { return 1 }
+
+			mrtnl := mocks.NewMocknltc(ctrl)
+			mrtnl.EXPECT().SetOption(nl.ExtendedAcknowledge, true).Return(nil).Times(1)
+			mrtnl.EXPECT().Close().Return(nil).Times(1) // the fd must be released
+			tcOpen = func(*tc.Config) (nltc, error) { return mrtnl, nil }
+
+			pObj := &packetparserObjects{} //nolint:typecheck // generated bpf2go type
+			pObj.EndpointIngressFilter = &ebpf.Program{}
+			pObj.EndpointEgressFilter = &ebpf.Program{}
+
+			p := &packetParser{
+				cfg:                 cfgPodLevelEnabled,
+				l:                   log.Logger().Named("test"),
+				objs:                pObj,
+				endpointIngressInfo: &ebpf.ProgramInfo{Name: "ingress"},
+				endpointEgressInfo:  &ebpf.ProgramInfo{Name: "egress"},
+				attachmentMap:       &sync.Map{},
+			}
+
+			linkAttr := netlink.LinkAttrs{Name: "tc-addfail", Index: 311}
+			p.attachViaTC(linkAttr, Veth)
+
+			_, ok := p.attachmentMap.Load(ifaceToKey(linkAttr))
+			assert.False(t, ok, "failed attach must not be recorded")
+		})
+	}
+}
+
+// Stop must wait for a callback already past the stopping check: the cbMu
+// barrier holds teardown until the in-flight attach finishes, so its Store is
+// visible to cleanAll and the attachment is released rather than leaked.
+func TestStopWaitsForInFlightCallback(t *testing.T) {
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	mq := mocks.NewMockqdisc(ctrl)
+	mq.EXPECT().Add(gomock.Any()).DoAndReturn(func(*tc.Object) error {
+		close(entered)
+		<-release
+		return nil
+	}).Times(1)
+	mq.EXPECT().Delete(gomock.Any()).Return(nil).Times(1) // cleanAll releases the attachment
+	getQdisc = func(nltc) qdisc { return mq }
+
+	mfilter := mocks.NewMockfilter(ctrl)
+	mfilter.EXPECT().Add(gomock.Any()).Return(nil).Times(2)
+	getFilter = func(nltc) filter { return mfilter }
+	getFD = func(_ *ebpf.Program) int { return 1 }
+
+	mrtnl := mocks.NewMocknltc(ctrl)
+	mrtnl.EXPECT().SetOption(nl.ExtendedAcknowledge, true).Return(nil).Times(1)
+	mrtnl.EXPECT().Close().Return(nil).Times(1) // via cleanAll
+	tcOpen = func(*tc.Config) (nltc, error) { return mrtnl, nil }
+
+	pObj := &packetparserObjects{} //nolint:typecheck // generated bpf2go type
+	pObj.EndpointIngressFilter = &ebpf.Program{}
+	pObj.EndpointEgressFilter = &ebpf.Program{}
+
+	p := &packetParser{
+		cfg:                 cfgPodLevelEnabled,
+		l:                   log.Logger().Named("test"),
+		objs:                pObj,
+		interfaceLockMap:    &sync.Map{},
+		endpointIngressInfo: &ebpf.ProgramInfo{Name: "ingress"},
+		endpointEgressInfo:  &ebpf.ProgramInfo{Name: "egress"},
+		attachmentMap:       &sync.Map{},
+	}
+
+	// Deliver a create on a separate goroutine, as the pubsub drain goroutine would.
+	callbackDone := make(chan struct{})
+	go func() {
+		defer close(callbackDone)
+		p.endpointWatcherCallbackFn(endpoint.NewEndpointEvent(endpoint.EndpointCreated,
+			netlink.LinkAttrs{Name: "in-flight", Index: 330}))
+	}()
+	<-entered // callback is now mid-attach, inside cbMu
+	// The callback captured the program pointers before blocking; drop objs so
+	// Stop doesn't Close zero-value bpf2go objects (ordered by the entered chan).
+	p.objs = nil
+
+	stopDone := make(chan struct{})
+	go func() {
+		defer close(stopDone)
+		_ = p.Stop()
+	}()
+
+	select {
+	case <-stopDone:
+		t.Fatal("Stop returned while a callback was still in flight")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	close(release)
+	<-callbackDone
+	select {
+	case <-stopDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Stop did not complete after the in-flight callback finished")
+	}
+
+	// cleanAll must have observed the Store (mock expectations above) and reset the map.
+	count := 0
+	p.attachmentMap.Range(func(_, _ interface{}) bool { count++; return true })
+	assert.Zero(t, count, "the in-flight attachment must be cleaned by Stop, not leaked")
+}
+
+// After Stop, an endpoint delivery still in flight (pubsub does not join it)
+// must be a no-op. The parser's maps are nil here, so a broken guard panics.
+func TestStopQuiescesEndpointCallback(t *testing.T) {
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
+
+	p := &packetParser{l: log.Logger().Named("test")}
+	require.NoError(t, p.Stop())
+
+	ev := endpoint.NewEndpointEvent(endpoint.EndpointCreated, netlink.LinkAttrs{Name: "late", Index: 320})
+	assert.NotPanics(t, func() { p.endpointWatcherCallbackFn(ev) },
+		"a delivery after Stop must be dropped by the stopping guard")
+}
+
+// The delete callback must detach a TCX attachment via cleanTCX (closing both
+// links) and drop the map entry — the TCX counterpart of the TC clean path.
+func TestEndpointWatcherCallbackFn_EndpointDeletedTCX(t *testing.T) {
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
+
+	p := &packetParser{
+		cfg:              cfgPodLevelEnabled,
+		l:                log.Logger().Named("test"),
+		interfaceLockMap: &sync.Map{},
+		attachmentMap:    &sync.Map{},
+	}
+	linkAttr := netlink.LinkAttrs{Name: "tcx-del", Index: 301}
+	key := ifaceToKey(linkAttr)
+	ingress := &fakeTCXLink{info: &link.Info{}}
+	egress := &fakeTCXLink{info: &link.Info{}}
+	p.interfaceLockMap.Store(key, &sync.Mutex{})
+	p.attachmentMap.Store(key, &attachmentValue{
+		attachmentType: attachmentTypeTCX,
+		tcxIngressLink: ingress,
+		tcxEgressLink:  egress,
+	})
+
+	p.endpointWatcherCallbackFn(&endpoint.EndpointEvent{Type: endpoint.EndpointDeleted, Obj: linkAttr})
+
+	_, ok := p.attachmentMap.Load(key)
+	assert.False(t, ok, "attachmentMap entry should be deleted")
+	assert.True(t, ingress.closed && egress.closed, "TCX links should be closed on delete")
+	_, lockOK := p.interfaceLockMap.Load(key)
+	assert.False(t, lockOK, "interfaceLockMap entry should be deleted")
+}
+
 func TestReadData_Error(t *testing.T) {
-	log.SetupZapLogger(log.GetDefaultLogOpts())
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -376,7 +816,7 @@ func TestReadData_RingBufClosed(t *testing.T) {
 }
 
 func TestReadDataPodLevelEnabled(t *testing.T) {
-	log.SetupZapLogger(log.GetDefaultLogOpts())
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -434,7 +874,7 @@ func TestReadDataPodLevelEnabled(t *testing.T) {
 }
 
 func TestStartPodLevelDisabled(t *testing.T) {
-	log.SetupZapLogger(log.GetDefaultLogOpts())
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
 	p := &packetParser{
 		cfg: cfgPodLevelDisabled,
 		l:   log.Logger().Named("test"),
@@ -604,7 +1044,7 @@ func TestStartWithDataAggregationLevelHigh(t *testing.T) {
 }
 
 func TestInitPodLevelDisabled(t *testing.T) {
-	log.SetupZapLogger(log.GetDefaultLogOpts())
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
 	p := &packetParser{
 		cfg: cfgPodLevelDisabled,
 		l:   log.Logger().Named("test"),
@@ -617,7 +1057,7 @@ func TestPacketParseGenerate(t *testing.T) {
 	takeBackup()
 	defer restoreBackup()
 
-	log.SetupZapLogger(log.GetDefaultLogOpts())
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
 	// Get the directory of the current test file.
 	_, filename, _, ok := runtime.Caller(0)
 	if !ok {
@@ -696,7 +1136,7 @@ func TestCompile(t *testing.T) {
 	takeBackup()
 	defer restoreBackup()
 
-	log.SetupZapLogger(log.GetDefaultLogOpts())
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
 	p := &packetParser{
 		cfg: cfgPodLevelEnabled,
 		l:   log.Logger().Named(name),

--- a/pkg/plugin/packetparser/types_linux.go
+++ b/pkg/plugin/packetparser/types_linux.go
@@ -5,6 +5,7 @@ package packetparser
 
 import (
 	"sync"
+	"sync/atomic"
 
 	kcfg "github.com/microsoft/retina/pkg/config"
 
@@ -77,9 +78,7 @@ var (
 
 // attachmentKey uniquely identifies a network interface for BPF program attachment.
 type attachmentKey struct {
-	name         string
-	hardwareAddr string
-	netNs        int
+	index int
 }
 
 // attachmentType represents the method used to attach BPF programs.
@@ -97,8 +96,16 @@ type attachmentValue struct {
 	qdisc *tc.Object
 	// TCX-specific fields
 	attachmentType attachmentType
-	tcxIngressLink link.Link
-	tcxEgressLink  link.Link
+	tcxIngressLink tcxLink
+	tcxEgressLink  tcxLink
+}
+
+// tcxLink is the subset of link.Link the parser needs. Narrower than link.Link
+// (whose unexported marker method blocks fakes) so tests can inject dead links
+// into the liveness check.
+type tcxLink interface {
+	Info() (*link.Info, error)
+	Close() error
 }
 
 //go:generate go run go.uber.org/mock/mockgen@v0.4.0 -source=types_linux.go -destination=mocks/mock_types_linux.go -package=mocks -exclude_interfaces=perfReader
@@ -112,6 +119,7 @@ type qdisc interface {
 // tc filter interface
 type filter interface {
 	Add(info *tc.Object) error
+	Get(info *tc.Msg) ([]tc.Object, error)
 }
 
 // netlink tc interface
@@ -153,12 +161,21 @@ type packetParser struct {
 	recordsChannel      chan perfRecord
 	externalChannel     chan *v1.Event
 	tcxSupported        bool // Whether TCX is supported on this system
+	// stopping and cbMu let Stop reach quiescence with the endpoint callback:
+	// pubsub's Unsubscribe does not wait for a delivery already in flight, so Stop
+	// sets stopping (new deliveries become no-ops), unsubscribes, then locks cbMu
+	// to wait out an in-flight callback before tearing down maps/programs.
+	stopping atomic.Bool
+	cbMu     sync.Mutex
 }
 
+// ifaceToKey keys on the interface index (the target of the TCX/TC attach),
+// which is stable for the interface's lifetime, unlike NetNsID/HardwareAddr,
+// which change as a pod's veth is moved into its netns during init — keying on
+// those caused the same interface to be seen under multiple keys and re-attached
+// ("already attached").
 func ifaceToKey(iface netlink.LinkAttrs) attachmentKey {
 	return attachmentKey{
-		name:         iface.Name,
-		hardwareAddr: iface.HardwareAddr.String(),
-		netNs:        iface.NetNsID,
+		index: iface.Index,
 	}
 }


### PR DESCRIPTION
# Description

**Stack 2/5** (splits #9) — base `endpointWatcherEventDriven/1-pubsub` (review after #15).

Makes packetparser's eBPF attach idempotent, self-healing, and safe to re-drive on every reconcile — the prerequisite for the level-triggered watchers later in the stack.

- **ifindex keying**: attachments key on the interface index (stable) instead of name/MAC/NetNsID, which change during the pod-init veth rename and caused duplicate-key re-attach churn.
- **liveness-checked idempotent attach**: a recorded attachment is re-verified against the kernel before being skipped — TCX via the link's ifindex, legacy TC via a targeted per-ifindex bpf-filter presence query (O(1)/probe) — so a stale attachment (interface deleted + index reused, or programs detached) re-attaches on the next reconcile.
- **hardened teardown / error handling**: a non-fatal `SetOption` failure no longer tears down a successful attach; failed attaches release the rtnetlink socket; neither the re-attach nor delete path deletes a clsact qdisc we can't prove is ours (index reuse can put another agent's qdisc at our recorded ifindex). `Stop` quiesces the endpoint callback (unsubscribe-first + barrier) so an in-flight attach can't race teardown and leak a live link.

The TC liveness probe matches on filter **presence**, deliberately no stronger (its repair path is an EEXIST-tolerant `Add`). The legacy-TC fallback's accepted gaps are documented at `tcAttachmentAlive`/`cleanAll`; all are absent under TCX (kernel 6.6+), the preferred transport.

## Related Issue

Splits #9 into a reviewable stack; this is part 2 of 5.

## Checklist

- [x] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [x] I signed and signed-off the commits (`git commit -S -s ...`).
- [x] I have correctly attributed the author(s) of the code.
- [x] I have tested the changes locally.
- [x] I have followed the project's style guidelines.
- [x] I have updated the documentation, if necessary.
- [x] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

Unit: TC/TCX attach + liveness (alive, dead→re-attach, no foreign-qdisc delete) + detach; attach failure paths (SetOption non-fatal, socket released, created-vs-pre-existing qdisc); Stop quiescence (post-Stop no-op; blocks on in-flight attach and cleans it). Real-kernel (`-tags=ebpf`): TC/TCX attach + liveness across interface delete; liveness-probe scale benchmarks.

## Additional Notes

Stack (review in order): 1 pubsub (#15) → **2 packetparser** → 3 watchermanager (#17) → 4 apiserver/cache (#18) → 5 endpoint/netlink (#19). Rebased on latest `microsoft/main` — packetparser saw substantial upstream changes (conntrack report interval, loader); CI validates the merge.
