### PR TITLE
feat(apiserver,cache): level-triggered convergence + snapshot-on-subscribe sources

### DIFF
--- a/cmd/standard/daemon.go
+++ b/cmd/standard/daemon.go
@@ -245,6 +245,9 @@ func (d *Daemon) Start() error {
 	if daemonConfig.EnablePodLevel {
 		pubSub := pubsub.New()
 		controllerCache := controllercache.New(pubSub)
+		// This is the cache the k8s controllers below feed; serve pod/svc/node
+		// snapshots to late pubsub subscribers from it.
+		controllerCache.RegisterSnapshotSources()
 		enrich := enricher.New(ctx, controllerCache)
 		//nolint:govet // shadowing this err is fine
 		fm, err := filtermanager.Init(5, daemonConfig.FilterMapMaxEntries) //nolint:gomnd // defaults

--- a/pkg/controllers/cache/cache.go
+++ b/pkg/controllers/cache/cache.go
@@ -64,6 +64,53 @@ func New(p pubsub.PubSubInterface) *Cache {
 	return c
 }
 
+// RegisterSnapshotSources registers this cache as the pubsub snapshot provider
+// for pods, services and nodes, so a subscriber that joins after the cache is
+// populated (e.g. the metrics module, which subscribes on its first
+// MetricsConfig reconcile) replays the current state immediately. Called
+// explicitly on the cache the k8s controllers feed, NOT from New: pubsub is a
+// process singleton with one source slot per topic, so a second incidental
+// cache.New (the controller manager creates one) would otherwise silently
+// steal the slot and serve empty snapshots.
+func (c *Cache) RegisterSnapshotSources() {
+	c.pubsub.RegisterSource(common.PubSubPods, c.podSnapshot)
+	c.pubsub.RegisterSource(common.PubSubSvc, c.svcSnapshot)
+	c.pubsub.RegisterSource(common.PubSubNode, c.nodeSnapshot)
+}
+
+// podSnapshot returns the current pods as add events.
+func (c *Cache) podSnapshot() []interface{} {
+	c.RLock()
+	defer c.RUnlock()
+	events := make([]interface{}, 0, len(c.epMap))
+	for _, ep := range c.epMap {
+		events = append(events, NewCacheEvent(EventTypePodAdded, ep))
+	}
+	return events
+}
+
+// svcSnapshot returns the current services as add events.
+func (c *Cache) svcSnapshot() []interface{} {
+	c.RLock()
+	defer c.RUnlock()
+	events := make([]interface{}, 0, len(c.svcMap))
+	for _, svc := range c.svcMap {
+		events = append(events, NewCacheEvent(EventTypeSvcAdded, svc))
+	}
+	return events
+}
+
+// nodeSnapshot returns the current nodes as add events.
+func (c *Cache) nodeSnapshot() []interface{} {
+	c.RLock()
+	defer c.RUnlock()
+	events := make([]interface{}, 0, len(c.nodeMap))
+	for _, node := range c.nodeMap {
+		events = append(events, NewCacheEvent(EventTypeNodeAdded, node))
+	}
+	return events
+}
+
 // GetPodByIP returns the retina endpoint for the given IP.
 func (c *Cache) GetPodByIP(ip string) *common.RetinaEndpoint {
 	c.RLock()
@@ -448,9 +495,13 @@ func (c *Cache) publish(t EventType, obj common.PublishObj) {
 		topic = common.PubSubNode
 	}
 
-	go func() {
-		c.pubsub.Publish(topic, cev)
-	}()
+	// Publish synchronously so events for the same key keep their order: a prior
+	// dispatch-per-goroutine let an add and a later delete of the same object race
+	// and arrive reversed, leaving consumers with a stale/leaked entry. Publish
+	// only enqueues (callbacks run on subscriber goroutines), so this stays cheap
+	// under c's lock, and it cannot deadlock — Subscribe invokes snapshot sources
+	// outside the PubSub lock, so there is no PubSub-lock -> cache-lock ordering.
+	c.pubsub.Publish(topic, cev)
 }
 
 func (c *Cache) SubscribeAPIServerFn(obj interface{}) {

--- a/pkg/controllers/cache/cache_test.go
+++ b/pkg/controllers/cache/cache_test.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/microsoft/retina/pkg/common"
 	"github.com/microsoft/retina/pkg/log"
@@ -15,8 +16,94 @@ import (
 	gomock "go.uber.org/mock/gomock"
 )
 
+// TestCachePublishOrderingSameKey verifies that events for the same object are
+// delivered in the order they were produced. A prior implementation published
+// each event on its own goroutine, letting an add and a later delete of the same
+// key arrive reversed and leave consumers with a stale entry.
+func TestCachePublishOrderingSameKey(t *testing.T) {
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
+	p := pubsub.New()
+	c := New(p)
+
+	var mu sync.Mutex
+	var order []EventType
+	done := make(chan struct{}, 1)
+	cb := pubsub.CallBackFunc(func(msg interface{}) {
+		ev, ok := msg.(*CacheEvent)
+		if !ok {
+			return
+		}
+		mu.Lock()
+		order = append(order, ev.Type)
+		n := len(order)
+		mu.Unlock()
+		if n == 2 {
+			select {
+			case done <- struct{}{}:
+			default:
+			}
+		}
+	})
+	id := p.Subscribe(common.PubSubPods, &cb)
+	defer p.Unsubscribe(common.PubSubPods, id) //nolint:errcheck // best-effort cleanup in test
+
+	ep := common.NewRetinaEndpoint("pod-order", "ns1", nil)
+	ep.SetIPs(&common.IPAddresses{IPv4: net.IPv4(10, 0, 0, 9)})
+	require.NoError(t, c.UpdateRetinaEndpoint(ep))
+	require.NoError(t, c.DeleteRetinaEndpoint(ep.Key()))
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("did not receive both pod events")
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Equal(t, []EventType{EventTypePodAdded, EventTypePodDeleted}, order,
+		"add must be delivered before delete for the same key")
+}
+
+// TestCacheSnapshotReplaysCurrentPod verifies the registered pod snapshot source
+// replays the current cache state to a subscriber that joins after the pod exists.
+func TestCacheSnapshotReplaysCurrentPod(t *testing.T) {
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
+	p := pubsub.New()
+	c := New(p)
+	// Explicit, as in the daemon: New must not register sources itself, or any
+	// incidental extra cache.New on the pubsub singleton (e.g. the controller
+	// manager's) would steal the topic's snapshot slot from the real cache.
+	c.RegisterSnapshotSources()
+
+	ep := common.NewRetinaEndpoint("pod-snap", "ns1", nil)
+	ep.SetIPs(&common.IPAddresses{IPv4: net.IPv4(10, 0, 0, 20)})
+	require.NoError(t, c.UpdateRetinaEndpoint(ep))
+
+	got := make(chan string, 1)
+	cb := pubsub.CallBackFunc(func(msg interface{}) {
+		ev, ok := msg.(*CacheEvent)
+		if !ok || ev.Type != EventTypePodAdded {
+			return
+		}
+		if rep, ok := ev.Obj.(*common.RetinaEndpoint); ok {
+			select {
+			case got <- rep.Name():
+			default:
+			}
+		}
+	})
+	id := p.Subscribe(common.PubSubPods, &cb)
+	defer p.Unsubscribe(common.PubSubPods, id) //nolint:errcheck // best-effort cleanup in test
+
+	select {
+	case name := <-got:
+		assert.Equal(t, "pod-snap", name, "late subscriber should receive the current pod via snapshot")
+	case <-time.After(2 * time.Second):
+		t.Fatal("late subscriber did not receive current pod via snapshot")
+	}
+}
+
 func TestNewCache(t *testing.T) {
-	log.SetupZapLogger(log.GetDefaultLogOpts())
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	p := pubsub.NewMockPubSubInterface(ctrl)
@@ -26,7 +113,7 @@ func TestNewCache(t *testing.T) {
 }
 
 func TestCacheEndpoints(t *testing.T) {
-	log.SetupZapLogger(log.GetDefaultLogOpts())
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	p := pubsub.NewMockPubSubInterface(ctrl)
@@ -97,7 +184,7 @@ func TestCacheEndpoints(t *testing.T) {
 }
 
 func TestCacheServices(t *testing.T) {
-	log.SetupZapLogger(log.GetDefaultLogOpts())
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	p := pubsub.NewMockPubSubInterface(ctrl)
@@ -145,7 +232,7 @@ func TestCacheServices(t *testing.T) {
 }
 
 func TestCacheNodes(t *testing.T) {
-	log.SetupZapLogger(log.GetDefaultLogOpts())
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	p := pubsub.NewMockPubSubInterface(ctrl)
@@ -182,7 +269,7 @@ func TestCacheNodes(t *testing.T) {
 }
 
 func TestAddPodSvcNodeSameIP(t *testing.T) {
-	log.SetupZapLogger(log.GetDefaultLogOpts())
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	p := pubsub.NewMockPubSubInterface(ctrl)
@@ -237,7 +324,7 @@ func TestAddPodSvcNodeSameIP(t *testing.T) {
 }
 
 func TestAddPodSvcNodeSameIPDiffNS(t *testing.T) {
-	log.SetupZapLogger(log.GetDefaultLogOpts())
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	p := pubsub.NewMockPubSubInterface(ctrl)
@@ -293,7 +380,7 @@ func TestAddPodSvcNodeSameIPDiffNS(t *testing.T) {
 }
 
 func TestAddPodDiffNs(t *testing.T) {
-	log.SetupZapLogger(log.GetDefaultLogOpts())
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	p := pubsub.NewMockPubSubInterface(ctrl)
@@ -341,7 +428,7 @@ func TestAddPodDiffNs(t *testing.T) {
 }
 
 func TestFailDelete(t *testing.T) {
-	log.SetupZapLogger(log.GetDefaultLogOpts())
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	p := pubsub.NewMockPubSubInterface(ctrl)
@@ -366,7 +453,7 @@ func TestFailDelete(t *testing.T) {
 }
 
 func TestCachingNamespace(t *testing.T) {
-	log.SetupZapLogger(log.GetDefaultLogOpts())
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	p := pubsub.NewMockPubSubInterface(ctrl)

--- a/pkg/module/metrics/metrics_module.go
+++ b/pkg/module/metrics/metrics_module.go
@@ -537,10 +537,11 @@ func handlePodEvent(
 		m.dirtyPods.ToAdd(podCacheEntry.IP.String(), podCacheEntry)
 	case cache.EventTypePodDeleted:
 		// Guard against spurious DELETE events during pod churn / IP reuse.
-		// The cache (pkg/controllers/cache/cache.go) updates its maps synchronously
-		// (epMap/ipToEpKey) and then publishes events asynchronously via a goroutine.
-		// So when we process this DELETE, if a new pod already reused the IP, the
-		// cache will still contain a valid entry. Deleting would incorrectly remove it.
+		// The cache (pkg/controllers/cache/cache.go) commits its maps
+		// (epMap/ipToEpKey) before publishing, and delivery happens later on this
+		// subscriber's drain goroutine. So when we process this DELETE, if a new
+		// pod already reused the IP, the cache will still contain a valid entry.
+		// Deleting would incorrectly remove it.
 		if endpoint := m.daemonCache.GetPodByIP(ip.String()); endpoint != nil {
 			m.l.Debug("Ignoring DELETE for reused IP — pod still exists in cache",
 				zap.String("deleted pod", pod.NamespacedName()),

--- a/pkg/watchers/apiserver/apiserver.go
+++ b/pkg/watchers/apiserver/apiserver.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"net/url"
 	"strings"
+	"sync"
 
 	"github.com/microsoft/retina/pkg/common"
 	cc "github.com/microsoft/retina/pkg/controllers/cache"
@@ -33,6 +34,7 @@ const (
 type ApiServerWatcher struct {
 	isRunning           bool
 	l                   *log.ZapLogger
+	mu                  sync.Mutex // guards current against concurrent snapshot reads
 	current             cache
 	new                 cache
 	apiServerHostName   string
@@ -102,9 +104,35 @@ func (a *ApiServerWatcher) Init(ctx context.Context) error {
 	}
 	a.apiServerHostName = hostName
 
+	// Register the snapshot source so a subscriber that joins after the watcher
+	// replays the current apiserver IP set immediately.
+	pubsub.New().RegisterSource(common.PubSubAPIServer, a.snapshot)
+
 	a.isRunning = true
 
 	return nil
+}
+
+// snapshot returns the current apiserver IPs as a single add event. Registered
+// as the pubsub source so late subscribers converge to the current set. It
+// applies the same IPv4 filter as Refresh's publishes: an IPv6 IP handed out
+// here would never be re-asserted nor deleted by the publish path, leaving the
+// subscriber with it forever.
+func (a *ApiServerWatcher) snapshot() []interface{} {
+	a.mu.Lock()
+	ips := make([]string, 0, len(a.current))
+	for k := range a.current {
+		if net.ParseIP(k).To4() == nil {
+			a.l.Warn("skipping non-IPv4 apiserver IP in snapshot", zap.String("ip", k))
+			continue
+		}
+		ips = append(ips, k)
+	}
+	a.mu.Unlock()
+	if len(ips) == 0 {
+		return nil
+	}
+	return []interface{}{cc.NewCacheEvent(cc.EventTypeAddAPIServerIPs, common.NewAPIServerObject(ips))}
 }
 
 // Stop stops the ApiServerWatcher.
@@ -124,42 +152,70 @@ func (a *ApiServerWatcher) Refresh(ctx context.Context) error {
 		return err
 	}
 
-	// Compare the new IPs with the old ones.
+	// created is only for operator-visible logging; adds are re-asserted from the
+	// full current set below. deleted drives removals.
 	created, deleted := a.diffCache()
-
-	createdIPs := []net.IP{}
-	deletedIPs := []net.IP{}
-
 	for _, v := range created {
-		a.l.Info("New Apiserver IPs:", zap.Any("ip", v))
-		ip := net.ParseIP(v.(string)).To4()
-		createdIPs = append(createdIPs, ip)
+		a.l.Info("New Apiserver IP", zap.Any("ip", v))
 	}
-
 	for _, v := range deleted {
-		a.l.Info("Deleted Apiserver IPs:", zap.Any("ip", v))
-		ip := net.ParseIP(v.(string)).To4()
-		deletedIPs = append(deletedIPs, ip)
+		a.l.Info("Deleted Apiserver IP", zap.Any("ip", v))
 	}
 
-	if len(createdIPs) > 0 {
-		a.publish(createdIPs, cc.EventTypeAddAPIServerIPs)
-		err := a.filterManager.AddIPs(createdIPs, "apiserver-watcher", fm.RequestMetadata{RuleID: "apiserver-watcher"})
-		if err != nil {
-			a.l.Error("Failed to add IPs to filter manager", zap.Error(err))
+	// currentIPs is the full live set (a.new); by construction it excludes
+	// anything in deleted (deleted = a.current - a.new). The filter map is
+	// IPv4-keyed, so skip anything To4 can't represent (e.g. IPv6 on dual-stack)
+	// — appending the nil would otherwise be re-asserted every refresh.
+	currentIPs := make([]net.IP, 0, len(a.new))
+	for k := range a.new {
+		if ip := net.ParseIP(k).To4(); ip != nil {
+			currentIPs = append(currentIPs, ip)
+		} else {
+			a.l.Warn("skipping non-IPv4 apiserver IP", zap.String("ip", k))
+		}
+	}
+	deletedIPs := make([]net.IP, 0, len(deleted))
+	for _, v := range deleted {
+		if ip := net.ParseIP(v.(string)).To4(); ip != nil {
+			deletedIPs = append(deletedIPs, ip)
+		} else {
+			a.l.Warn("skipping non-IPv4 apiserver IP", zap.String("ip", v.(string)))
 		}
 	}
 
+	// Commit current before publishing. snapshot() (served to new subscribers)
+	// reads a.current, so committing first ensures a subscriber joining during
+	// this refresh never sees a snapshot that still contains an IP whose delete we
+	// are about to publish — otherwise it would get the stale add via snapshot but
+	// miss the delete and keep the IP forever. currentIPs/deletedIPs are already
+	// captured above, so the publishes below are unaffected.
+	a.mu.Lock()
+	a.current = a.new.deepcopy()
+	a.mu.Unlock()
+	a.new = nil
+
+	// Publish deletes BEFORE the add re-assert. The cache keys all apiserver IPs
+	// under one endpoint (kubernetes-apiserver) and handles a delete by dropping
+	// the whole entry, so a delete published after the add would wipe the set
+	// just asserted and leave the cache without an apiserver endpoint until the
+	// next refresh. Delete-then-add converges immediately; the per-IP consumers
+	// are order-insensitive since the two sets are disjoint.
 	if len(deletedIPs) > 0 {
 		a.publish(deletedIPs, cc.EventTypeDeleteAPIServerIPs)
-		err := a.filterManager.DeleteIPs(deletedIPs, "apiserver-watcher", fm.RequestMetadata{RuleID: "apiserver-watcher"})
-		if err != nil {
+		if err := a.filterManager.DeleteIPs(deletedIPs, "apiserver-watcher", fm.RequestMetadata{RuleID: "apiserver-watcher"}); err != nil {
 			a.l.Error("Failed to delete IPs from filter manager", zap.Error(err))
 		}
 	}
 
-	a.current = a.new.deepcopy()
-	a.new = nil
+	// Re-assert all current IPs every refresh (level-triggered, idempotent):
+	// consumers self-heal a missed add regardless of subscribe timing, and this
+	// retries any filter-map add that previously failed.
+	if len(currentIPs) > 0 {
+		a.publish(currentIPs, cc.EventTypeAddAPIServerIPs)
+		if err := a.filterManager.AddIPs(currentIPs, "apiserver-watcher", fm.RequestMetadata{RuleID: "apiserver-watcher"}); err != nil {
+			a.l.Error("Failed to add IPs to filter manager", zap.Error(err))
+		}
+	}
 
 	return nil
 }

--- a/pkg/watchers/apiserver/apiserver_test.go
+++ b/pkg/watchers/apiserver/apiserver_test.go
@@ -9,12 +9,17 @@ import (
 	"errors"
 	"fmt"
 	"math/rand"
+	"net"
+	"sync"
 	"testing"
 	"time"
 
+	"github.com/microsoft/retina/pkg/common"
 	kcfg "github.com/microsoft/retina/pkg/config"
+	cc "github.com/microsoft/retina/pkg/controllers/cache"
 	"github.com/microsoft/retina/pkg/log"
 	filtermanagermocks "github.com/microsoft/retina/pkg/managers/filtermanager"
+	"github.com/microsoft/retina/pkg/pubsub"
 	"github.com/microsoft/retina/pkg/watchers/apiserver/mocks"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -31,7 +36,7 @@ import (
 var errDNS = errors.New("DNS error")
 
 func TestGetWatcher(t *testing.T) {
-	log.SetupZapLogger(log.GetDefaultLogOpts())
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
 
 	a := Watcher(kcfg.DefaultFilterMapMaxEntries)
 	assert.NotNil(t, a)
@@ -41,7 +46,7 @@ func TestGetWatcher(t *testing.T) {
 }
 
 func TestAPIServerWatcherStop(t *testing.T) {
-	log.SetupZapLogger(log.GetDefaultLogOpts())
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
 	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
 	defer cancel()
 	ctrl := gomock.NewController(t)
@@ -71,7 +76,7 @@ func TestAPIServerWatcherStop(t *testing.T) {
 }
 
 func TestRefresh(t *testing.T) {
-	log.SetupZapLogger(log.GetDefaultLogOpts())
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -100,8 +105,198 @@ func TestRefresh(t *testing.T) {
 	assert.NoError(t, a.Refresh(context.Background()), "Expected no error when refreshing the cache")
 }
 
+// TestRefreshSkipsNonIPv4 verifies IPv6 apiserver IPs (e.g. dual-stack) are
+// skipped rather than fed to the IPv4-keyed filter map as nils — which the
+// level-triggered re-assert would otherwise repeat every refresh.
+func TestRefreshSkipsNonIPv4(t *testing.T) {
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockedResolver := mocks.NewMockIHostResolver(ctrl)
+	mockedResolver.EXPECT().LookupHost(gomock.Any(), gomock.Any()).Return([]string{"10.9.9.9", "fd00::1"}, nil).AnyTimes()
+
+	var got []net.IP
+	mockedFilterManager := filtermanagermocks.NewMockIFilterManager(ctrl)
+	mockedFilterManager.EXPECT().AddIPs(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(ips []net.IP, _ filtermanagermocks.Requestor, _ filtermanagermocks.RequestMetadata) error {
+			got = ips
+			return nil
+		}).AnyTimes()
+	mockedFilterManager.EXPECT().DeleteIPs(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+
+	a := &ApiServerWatcher{
+		l:             log.Logger().Named("apiserver-watcher"),
+		hostResolver:  mockedResolver,
+		filterManager: mockedFilterManager,
+		client:        getMockKubeClient(),
+	}
+
+	require.NoError(t, a.Refresh(context.Background()))
+
+	// 3 IPv4s from the mock kube client + 1 from the resolver; fd00::1 skipped.
+	assert.Len(t, got, 4, "expected only the IPv4 addresses")
+	for _, ip := range got {
+		assert.NotNil(t, ip, "no nil entries may reach the filter manager")
+	}
+}
+
+// TestSnapshot verifies the pubsub snapshot source returns the current apiserver
+// IP set as a single add event (and nothing when empty), so a late subscriber
+// converges to the current state.
+func TestSnapshot(t *testing.T) {
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
+
+	a := &ApiServerWatcher{
+		l:       log.Logger().Named("apiserver-watcher"),
+		current: cache{},
+	}
+	assert.Nil(t, a.snapshot(), "empty current should yield no snapshot events")
+
+	a.current = cache{"10.0.0.1": struct{}{}, "10.0.0.2": struct{}{}, "fd00::1": struct{}{}}
+	snap := a.snapshot()
+	require.Len(t, snap, 1, "snapshot should be a single add event carrying all current IPs")
+	ev, ok := snap[0].(*cc.CacheEvent)
+	require.True(t, ok, "snapshot item should be a *cache.CacheEvent")
+	assert.Equal(t, cc.EventTypeAddAPIServerIPs, ev.Type, "snapshot event should be an apiserver-IP add")
+	obj, ok := ev.Obj.(*common.APIServerObject)
+	require.True(t, ok, "snapshot event payload should be an *common.APIServerObject")
+	got := make([]string, 0, len(obj.IPs()))
+	for _, ip := range obj.IPs() {
+		got = append(got, ip.String())
+	}
+	assert.ElementsMatch(t, []string{"10.0.0.1", "10.0.0.2"}, got,
+		"snapshot must carry the IPv4 set and skip IPv6, matching the publish path's filter")
+
+	// All-IPv6 current: nothing publishable, so no snapshot event at all.
+	a.current = cache{"fd00::2": struct{}{}}
+	assert.Nil(t, a.snapshot(), "an all-IPv6 set should yield no snapshot events")
+}
+
+// TestRefreshPublishesDeleteBeforeAdd pins the publish order on an IP change.
+// The cache keys every apiserver IP under one endpoint and handles a delete by
+// dropping the whole entry, so a delete published after the add re-assert would
+// wipe the set just asserted and leave the cache without an apiserver endpoint
+// until the next refresh.
+func TestRefreshPublishesDeleteBeforeAdd(t *testing.T) {
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockedResolver := mocks.NewMockIHostResolver(ctrl)
+	gomock.InOrder(
+		mockedResolver.EXPECT().LookupHost(gomock.Any(), gomock.Any()).Return([]string{"10.0.0.1", "10.0.0.2"}, nil).Times(1),
+		mockedResolver.EXPECT().LookupHost(gomock.Any(), gomock.Any()).Return([]string{"10.0.0.1"}, nil).Times(1),
+	)
+	mockedFilterManager := filtermanagermocks.NewMockIFilterManager(ctrl)
+	mockedFilterManager.EXPECT().AddIPs(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	mockedFilterManager.EXPECT().DeleteIPs(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+
+	a := &ApiServerWatcher{
+		l:             log.Logger().Named("apiserver-watcher"),
+		hostResolver:  mockedResolver,
+		filterManager: mockedFilterManager,
+		client:        getMockKubeClient(),
+		current:       cache{},
+	}
+
+	// Record the order of published event types on the apiserver topic.
+	var mu sync.Mutex
+	type published struct {
+		typ cc.EventType
+		ips []string
+	}
+	var events []published
+	fn := pubsub.CallBackFunc(func(msg interface{}) {
+		ev, ok := msg.(*cc.CacheEvent)
+		if !ok {
+			return
+		}
+		obj, ok := ev.Obj.(*common.APIServerObject)
+		if !ok || obj.EP == nil {
+			return
+		}
+		ips := []string{}
+		for _, ip := range obj.IPs() {
+			ips = append(ips, ip.String())
+		}
+		mu.Lock()
+		events = append(events, published{ev.Type, ips})
+		mu.Unlock()
+	})
+	ps := pubsub.New()
+	id := ps.Subscribe(common.PubSubAPIServer, &fn)
+	defer ps.Unsubscribe(common.PubSubAPIServer, id) //nolint:errcheck // best-effort cleanup in test
+
+	require.NoError(t, a.Refresh(context.Background()))
+	require.NoError(t, a.Refresh(context.Background())) // drops 10.0.0.2
+
+	assert.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		del := -1
+		for i, e := range events {
+			if e.typ == cc.EventTypeDeleteAPIServerIPs {
+				del = i
+				break
+			}
+		}
+		if del < 0 {
+			return false
+		}
+		assert.Equal(t, []string{"10.0.0.2"}, events[del].ips, "the delete must carry the dropped IP")
+		// The re-assert of the surviving set must come after the delete, so
+		// consumers that drop the whole entry on delete end converged.
+		for _, e := range events[del+1:] {
+			if e.typ == cc.EventTypeAddAPIServerIPs {
+				return true
+			}
+		}
+		return false
+	}, 2*time.Second, 10*time.Millisecond,
+		"expected the delete to be published before the add re-assert")
+}
+
+// TestSnapshotConcurrentWithRefresh hammers snapshot() while Refresh commits —
+// under -race this pins the mutex protecting a.current, the only thing that
+// makes serving snapshots to arbitrary subscriber goroutines safe.
+func TestSnapshotConcurrentWithRefresh(t *testing.T) {
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockedResolver := mocks.NewMockIHostResolver(ctrl)
+	mockedResolver.EXPECT().LookupHost(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(context.Context, string) ([]string, error) {
+			return []string{randomIP(), randomIP()}, nil
+		}).AnyTimes()
+	mockedFilterManager := filtermanagermocks.NewMockIFilterManager(ctrl)
+	mockedFilterManager.EXPECT().AddIPs(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	mockedFilterManager.EXPECT().DeleteIPs(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+
+	a := &ApiServerWatcher{
+		l:             log.Logger().Named("apiserver-watcher"),
+		hostResolver:  mockedResolver,
+		filterManager: mockedFilterManager,
+		client:        getMockKubeClient(),
+		current:       cache{},
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for range 200 {
+			a.snapshot()
+		}
+	}()
+	for range 10 {
+		require.NoError(t, a.Refresh(context.Background()))
+	}
+	<-done
+}
+
 func TestDiffCache(t *testing.T) {
-	log.SetupZapLogger(log.GetDefaultLogOpts())
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -128,7 +323,7 @@ func TestDiffCache(t *testing.T) {
 }
 
 func TestRefreshLookUpAlwaysFail(t *testing.T) {
-	log.SetupZapLogger(log.GetDefaultLogOpts())
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -150,7 +345,7 @@ func TestRefreshLookUpAlwaysFail(t *testing.T) {
 }
 
 func TestInitWithIncorrectURL(t *testing.T) {
-	log.SetupZapLogger(log.GetDefaultLogOpts())
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 


### PR DESCRIPTION
# Description

**Stack 4/5** (splits #9) — base `endpointWatcherEventDriven/3-watchermanager` (review after #17).

Makes the apiserver watcher and the object cache level-triggered and snapshot-serving, so late subscribers converge and same-key events can't reorder.

- **apiserver**: re-asserts the full current IP set every refresh (idempotent, self-heals a missed add and retries a failed filter-map add); commits `current` before publishing (closes a stale-delete window); publishes **deletes before the add re-assert** (the cache keys all apiserver IPs under one endpoint and drops the whole entry on delete, so a trailing delete would wipe the just-asserted set); skips non-IPv4 IPs consistently in both publishes and the snapshot.
- **cache**: synchronous ordered `publish` (a prior goroutine-per-publish let a same-key add/delete race and reverse); pod/svc/node snapshot sources; `RegisterSnapshotSources()` is called **explicitly by the daemon** on the controller-fed cache rather than from the constructor (pubsub is a process singleton with one source slot per topic — an incidental second `cache.New` would otherwise steal the slot and serve empty snapshots).

## Related Issue

Splits #9 into a reviewable stack; this is part 4 of 5. Depends on the pubsub `RegisterSource` API from #15.

## Checklist

- [ ] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [x] I signed and signed-off the commits (`git commit -S -s ...`).
- [x] I have correctly attributed the author(s) of the code.
- [x] I have tested the changes locally.
- [x] I have followed the project's style guidelines.
- [x] I have updated the documentation, if necessary.
- [x] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

apiserver: snapshot (IPv4-filtered, race-tested against Refresh), delete-before-add ordering, IPv4-skip on refresh. cache: same-key publish ordering, late-subscriber snapshot replay, `New` does-not-self-register. Race-clean.

## Additional Notes

Stack (review in order): 1 pubsub (#15) → 2 packetparser (#16) → 3 watchermanager (#17) → **4 apiserver/cache** → 5 endpoint/netlink (#19). Rebased on latest `microsoft/main`.
