### PR TITLE
feat(endpoint): netlink-driven veth attach with index-reuse detection

### DIFF
--- a/.github/workflows/test-ebpf.yaml
+++ b/.github/workflows/test-ebpf.yaml
@@ -6,12 +6,14 @@ on:
       - 'pkg/plugin/**/_cprog/**'
       - 'pkg/plugin/**/*_ebpf_test.go'
       - 'pkg/plugin/ebpftest/**'
+      - 'pkg/watchers/**'
   pull_request:
     branches: [main]
     paths:
       - 'pkg/plugin/**/_cprog/**'
       - 'pkg/plugin/**/*_ebpf_test.go'
       - 'pkg/plugin/ebpftest/**'
+      - 'pkg/watchers/**'
   workflow_dispatch:
 
 permissions:
@@ -46,4 +48,4 @@ jobs:
 
       - name: Run eBPF program tests
         run: |
-          sudo $(which go) test -tags=ebpf -v -count=1 ./pkg/plugin/...
+          sudo $(which go) test -tags=ebpf -v -count=1 ./pkg/plugin/... ./pkg/watchers/...

--- a/Makefile
+++ b/Makefile
@@ -466,8 +466,8 @@ test: # Run unit tests.
 	bash -o pipefail -c 'KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use -p path)" go test -tags=unit,dashboard -skip=TestE2E* -coverprofile=coverage.out -v -json ./... | ./test-summary --progress --verbose'
 
 .PHONY: test-ebpf
-test-ebpf: # Run eBPF program tests (requires root/CAP_BPF).
-	sudo $$(which go) test -tags=ebpf -v -count=1 ./pkg/plugin/...
+test-ebpf: # Run eBPF program tests (requires root/CAP_BPF; watcher tests need NET_ADMIN).
+	sudo $$(which go) test -tags=ebpf -v -count=1 ./pkg/plugin/... ./pkg/watchers/...
 
 coverage: # Code coverage.
 #	go generate ./... && go test -tags=unit -coverprofile=coverage.out.tmp ./...

--- a/deploy/hubble/manifests/controller/helm/retina/templates/agent/configmap.yaml
+++ b/deploy/hubble/manifests/controller/helm/retina/templates/agent/configmap.yaml
@@ -117,6 +117,8 @@ data:
     monitorSockPath: {{ .Values.monitorSockPath }}
     packetParserRingBuffer: {{ .Values.packetParserRingBuffer }}
     packetParserRingBufferSize: {{ .Values.packetParserRingBufferSize }}
+    enableEndpointNetlinkEvents: {{ .Values.enableEndpointNetlinkEvents }}
+    watcherRefreshInterval: {{ .Values.watcherRefreshInterval }}
 {{- end}}
 ---
 {{- if .Values.os.windows}}

--- a/deploy/hubble/manifests/controller/helm/retina/values.yaml
+++ b/deploy/hubble/manifests/controller/helm/retina/values.yaml
@@ -84,6 +84,10 @@ packetParserRingBuffer: "disabled"
 # Invalid values cause startup to fail with a validation error.
 # This value is not applied when ring buffers are disabled.
 packetParserRingBufferSize: 8388608
+# Attach eBPF programs on veth netlink events instead of waiting for the watcher refresh.
+enableEndpointNetlinkEvents: false
+# Watcher re-list interval.
+watcherRefreshInterval: "30s"
 
 imagePullSecrets: []
 nameOverride: "retina"

--- a/deploy/standard/manifests/controller/helm/retina/templates/configmap.yaml
+++ b/deploy/standard/manifests/controller/helm/retina/templates/configmap.yaml
@@ -31,6 +31,8 @@ data:
     packetParserRingBuffer: {{ .Values.packetParserRingBuffer }}
     packetParserRingBufferSize: {{ .Values.packetParserRingBufferSize }}
     filterMapMaxEntries: {{ .Values.filterMapMaxEntries }}
+    enableEndpointNetlinkEvents: {{ .Values.enableEndpointNetlinkEvents }}
+    watcherRefreshInterval: {{ .Values.watcherRefreshInterval }}
 {{- end}}
 ---
 {{- if .Values.os.windows}}

--- a/deploy/standard/manifests/controller/helm/retina/values.yaml
+++ b/deploy/standard/manifests/controller/helm/retina/values.yaml
@@ -73,6 +73,10 @@ packetParserRingBufferSize: 8388608
 # This map tracks IP addresses of pods of interest for network observability.
 # Default: 255. Increase for large clusters with many tracked pods.
 filterMapMaxEntries: 255
+# Attach eBPF programs on veth netlink events instead of waiting for the watcher refresh.
+enableEndpointNetlinkEvents: false
+# Watcher re-list interval.
+watcherRefreshInterval: "30s"
 
 imagePullSecrets: []
 nameOverride: "retina"

--- a/docs/02-Installation/03-Config.md
+++ b/docs/02-Installation/03-Config.md
@@ -57,6 +57,8 @@ Apply to both Agent and Operator.
 * `conntrackReportInterval`: Periodic interval (in `time.Duration`, default `30s`) at which conntrack reports active connections in high data aggregation mode. Values below `1s` fall back to the default. See [Report interval](../03-Metrics/plugins/Linux/packetparser.md#report-interval) for more details.
 * `packetParserRingBuffer`: Selects the kernel-to-userspace transport for `packetparser`. Accepted values: `enabled` (ring buffer) or `disabled` (perf event array). `auto` is reserved for future use.
 * `packetParserRingBufferSize`: Ring buffer size in bytes when `packetParserRingBuffer=enabled`. Must be a power of two between the kernel page size and 1GiB (inclusive); invalid values cause startup to fail.
+* `enableEndpointNetlinkEvents`: If true, the endpoint watcher subscribes to netlink link events and reconciles immediately when a veth appears or disappears, so eBPF programs attach within milliseconds of pod creation instead of waiting for the next periodic refresh. Default `false`. Linux only; the periodic refresh remains as a backstop.
+* `watcherRefreshInterval`: Interval (in `time.Duration`, default `30s`) at which the endpoint and API server watchers re-list and reconcile state. With `enableEndpointNetlinkEvents` this acts as a self-healing backstop rather than the primary attach path.
 
 ## Operator Configuration
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -56,10 +56,10 @@ var (
 		"telemetryInterval smaller than %v is not allowed",
 		MinTelemetryInterval,
 	)
-	DefaultTelemetryInterval          = 15 * time.Minute
-	DefaultSamplingRate        uint32 = 1
-	DefaultFilterMapMaxEntries uint32 = 255
-	DefaultConntrackReportInterval    = 30 * time.Second
+	DefaultTelemetryInterval              = 15 * time.Minute
+	DefaultSamplingRate            uint32 = 1
+	DefaultFilterMapMaxEntries     uint32 = 255
+	DefaultConntrackReportInterval        = 30 * time.Second
 )
 
 func (l *Level) UnmarshalText(text []byte) error {
@@ -120,24 +120,25 @@ type Config struct {
 	EnabledPlugin   []string      `yaml:"enabledPlugin"`
 	MetricsInterval time.Duration `yaml:"metricsInterval"`
 	// Deprecated: Use only MetricsInterval instead in the go code.
-	MetricsIntervalDuration    time.Duration              `yaml:"metricsIntervalDuration"`
-	EnableTelemetry            bool                       `yaml:"enableTelemetry"`
-	EnableRetinaEndpoint       bool                       `yaml:"enableRetinaEndpoint"`
-	EnablePodLevel             bool                       `yaml:"enablePodLevel"`
-	EnableConntrackMetrics     bool                       `yaml:"enableConntrackMetrics"`
-	RemoteContext              bool                       `yaml:"remoteContext"`
-	EnableAnnotations          bool                       `yaml:"enableAnnotations"`
-	BypassLookupIPOfInterest   bool                       `yaml:"bypassLookupIPOfInterest"`
-	DataAggregationLevel       Level                      `yaml:"dataAggregationLevel"`
-	MonitorSockPath            string                     `yaml:"monitorSockPath"`
-	TelemetryInterval          time.Duration              `yaml:"telemetryInterval"`
-	DataSamplingRate           uint32                     `yaml:"dataSamplingRate"`
-	ConntrackReportInterval    time.Duration              `yaml:"conntrackReportInterval"`
-	PacketParserRingBuffer     PacketParserRingBufferMode `yaml:"packetParserRingBuffer"`
-	PacketParserRingBufferSize uint32                     `yaml:"packetParserRingBufferSize"`
-	FilterMapMaxEntries        uint32                     `yaml:"filterMapMaxEntries"`
-	EnableTCX                  TCXMode                    `yaml:"enableTCX"`
-	WatcherRefreshInterval     time.Duration              `yaml:"watcherRefreshInterval"`
+	MetricsIntervalDuration     time.Duration              `yaml:"metricsIntervalDuration"`
+	EnableTelemetry             bool                       `yaml:"enableTelemetry"`
+	EnableRetinaEndpoint        bool                       `yaml:"enableRetinaEndpoint"`
+	EnablePodLevel              bool                       `yaml:"enablePodLevel"`
+	EnableConntrackMetrics      bool                       `yaml:"enableConntrackMetrics"`
+	RemoteContext               bool                       `yaml:"remoteContext"`
+	EnableAnnotations           bool                       `yaml:"enableAnnotations"`
+	BypassLookupIPOfInterest    bool                       `yaml:"bypassLookupIPOfInterest"`
+	DataAggregationLevel        Level                      `yaml:"dataAggregationLevel"`
+	MonitorSockPath             string                     `yaml:"monitorSockPath"`
+	TelemetryInterval           time.Duration              `yaml:"telemetryInterval"`
+	DataSamplingRate            uint32                     `yaml:"dataSamplingRate"`
+	ConntrackReportInterval     time.Duration              `yaml:"conntrackReportInterval"`
+	PacketParserRingBuffer      PacketParserRingBufferMode `yaml:"packetParserRingBuffer"`
+	PacketParserRingBufferSize  uint32                     `yaml:"packetParserRingBufferSize"`
+	FilterMapMaxEntries         uint32                     `yaml:"filterMapMaxEntries"`
+	EnableTCX                   TCXMode                    `yaml:"enableTCX"`
+	EnableEndpointNetlinkEvents bool                       `yaml:"enableEndpointNetlinkEvents"`
+	WatcherRefreshInterval      time.Duration              `yaml:"watcherRefreshInterval"`
 }
 
 func GetConfig(cfgFilename string) (*Config, error) {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -30,7 +30,9 @@ func TestGetConfig(t *testing.T) {
 		c.TelemetryInterval != 15*time.Minute ||
 		c.DataAggregationLevel != Low ||
 		c.DataSamplingRate != 1 ||
-		c.PacketParserRingBuffer != PacketParserRingBufferDisabled {
+		c.PacketParserRingBuffer != PacketParserRingBufferDisabled ||
+		!c.EnableEndpointNetlinkEvents ||
+		c.WatcherRefreshInterval != 45*time.Second {
 		t.Errorf("Expeted config should be same as ./testwith/config.yaml; instead got %+v", c)
 	}
 }

--- a/pkg/config/testwith/config.yaml
+++ b/pkg/config/testwith/config.yaml
@@ -12,3 +12,5 @@ dataAggregationLevel: "low"
 telemetryInterval: "15m"
 packetParserRingBuffer: "disabled"
 packetParserRingBufferSize: 8388608
+enableEndpointNetlinkEvents: true
+watcherRefreshInterval: "45s"

--- a/pkg/managers/pluginmanager/pluginmanager.go
+++ b/pkg/managers/pluginmanager/pluginmanager.go
@@ -57,7 +57,7 @@ func NewPluginManager(cfg *kcfg.Config, tel telemetry.Telemetry, logger *slog.Lo
 
 	if mgr.cfg.EnablePodLevel {
 		mgr.l.Info("plugin manager has pod level enabled")
-		mgr.watcherManager = watchermanager.NewWatcherManager(mgr.cfg.FilterMapMaxEntries, mgr.cfg.WatcherRefreshInterval)
+		mgr.watcherManager = watchermanager.NewWatcherManager(mgr.cfg.FilterMapMaxEntries, mgr.cfg.EnableEndpointNetlinkEvents, mgr.cfg.WatcherRefreshInterval)
 	} else {
 		mgr.l.Info("plugin manager has pod level disabled")
 	}

--- a/pkg/managers/watchermanager/watchermanager.go
+++ b/pkg/managers/watchermanager/watchermanager.go
@@ -19,13 +19,13 @@ const (
 	DefaultRefreshRate = 30 * time.Second
 )
 
-func NewWatcherManager(filterMapMaxEntries uint32, refreshRate time.Duration) *WatcherManager {
+func NewWatcherManager(filterMapMaxEntries uint32, enableEndpointNetlinkEvents bool, refreshRate time.Duration) *WatcherManager {
 	if refreshRate <= 0 {
 		refreshRate = DefaultRefreshRate
 	}
 	return &WatcherManager{
 		Watchers: []IWatcher{
-			endpoint.Watcher(),
+			endpoint.Watcher(enableEndpointNetlinkEvents),
 			apiserver.Watcher(filterMapMaxEntries),
 		},
 		l:           log.Logger().Named("watcher-manager"),

--- a/pkg/managers/watchermanager/watchermanager_test.go
+++ b/pkg/managers/watchermanager/watchermanager_test.go
@@ -23,7 +23,7 @@ func TestStopWatcherManagerGracefully(t *testing.T) {
 	ctl := gomock.NewController(t)
 	defer ctl.Finish()
 	log.SetupZapLogger(log.GetDefaultLogOpts())
-	mgr := NewWatcherManager(kcfg.DefaultFilterMapMaxEntries, 0)
+	mgr := NewWatcherManager(kcfg.DefaultFilterMapMaxEntries, false, 0)
 
 	mockAPIServerWatcher := mock.NewMockIWatcher(ctl)
 	mockEndpointWatcher := mock.NewMockIWatcher(ctl)
@@ -63,7 +63,7 @@ func TestWatcherInitFailsGracefully(t *testing.T) {
 	mockAPIServerWatcher := mock.NewMockIWatcher(ctl)
 	mockEndpointWatcher := mock.NewMockIWatcher(ctl)
 
-	mgr := NewWatcherManager(kcfg.DefaultFilterMapMaxEntries, 0)
+	mgr := NewWatcherManager(kcfg.DefaultFilterMapMaxEntries, false, 0)
 	mgr.Watchers = []IWatcher{
 		mockAPIServerWatcher,
 		mockEndpointWatcher,
@@ -87,7 +87,7 @@ func TestStartUnwindsOnInitFailure(t *testing.T) {
 	first := mock.NewMockIWatcher(ctl)
 	second := mock.NewMockIWatcher(ctl)
 
-	mgr := NewWatcherManager(kcfg.DefaultFilterMapMaxEntries, 0)
+	mgr := NewWatcherManager(kcfg.DefaultFilterMapMaxEntries, false, 0)
 	mgr.Watchers = []IWatcher{first, second}
 
 	first.EXPECT().Init(gomock.Any()).Return(nil).Times(1)
@@ -115,7 +115,7 @@ func TestStopContinuesPastFailedWatcher(t *testing.T) {
 	failing := mock.NewMockIWatcher(ctl)
 	healthy := mock.NewMockIWatcher(ctl)
 
-	mgr := NewWatcherManager(kcfg.DefaultFilterMapMaxEntries, 0)
+	mgr := NewWatcherManager(kcfg.DefaultFilterMapMaxEntries, false, 0)
 	mgr.Watchers = []IWatcher{failing, healthy}
 
 	failing.EXPECT().Stop(gomock.Any()).Return(errInitFailed).Times(1)
@@ -133,7 +133,7 @@ func TestRunWatcherInitialReconcile(t *testing.T) {
 	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
 
 	w := mock.NewMockIWatcher(ctl)
-	mgr := NewWatcherManager(kcfg.DefaultFilterMapMaxEntries, time.Hour) // no tick fires during the test
+	mgr := NewWatcherManager(kcfg.DefaultFilterMapMaxEntries, false, time.Hour) // no tick fires during the test
 	mgr.Watchers = []IWatcher{w}
 
 	refreshed := make(chan struct{}, 1)
@@ -163,7 +163,7 @@ func TestRunWatcherSurvivesRefreshErrors(t *testing.T) {
 	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
 
 	w := mock.NewMockIWatcher(ctl)
-	mgr := NewWatcherManager(kcfg.DefaultFilterMapMaxEntries, 10*time.Millisecond)
+	mgr := NewWatcherManager(kcfg.DefaultFilterMapMaxEntries, false, 10*time.Millisecond)
 	mgr.Watchers = []IWatcher{w}
 
 	var calls atomic.Int32
@@ -185,7 +185,7 @@ func TestWatcherStopWithoutStart(t *testing.T) {
 	defer ctl.Finish()
 	log.SetupZapLogger(log.GetDefaultLogOpts())
 
-	mgr := NewWatcherManager(kcfg.DefaultFilterMapMaxEntries, 0)
+	mgr := NewWatcherManager(kcfg.DefaultFilterMapMaxEntries, false, 0)
 
 	err := mgr.Stop(context.Background())
 	require.Nil(t, err, "Expected no error when stopping watcher manager without starting it")

--- a/pkg/watchers/endpoint/endpoint.go
+++ b/pkg/watchers/endpoint/endpoint.go
@@ -5,6 +5,7 @@ package endpoint
 
 import (
 	"context"
+	"sync"
 
 	"github.com/microsoft/retina/pkg/common"
 	"github.com/microsoft/retina/pkg/log"
@@ -13,17 +14,34 @@ import (
 )
 
 type EndpointWatcher struct {
-	isRunning bool
-	l         *log.ZapLogger
-	current   cache
-	new       cache
-	p         pubsub.PubSubInterface
+	isRunning           bool
+	enableNetlinkEvents bool
+	l                   *log.ZapLogger
+	current             cache
+	new                 cache
+	p                   pubsub.PubSubInterface
+	mu                  sync.Mutex
+	// cancel tears down the goroutines Init started (netlink subscription and
+	// refresher). Derived from Init's ctx, so parent cancellation propagates and
+	// Stop works for standalone callers too — one signal, not a ctx/stop-channel pair.
+	cancel context.CancelFunc
+	// deletedIndexes holds interface indexes that netlink reported removed since
+	// the last refresh, guarded by delMu (the netlink reader writes it, Refresh
+	// drains it). It lets Refresh detect a delete+recreate that reused an index
+	// within one reconcile — which diffCache alone cannot see. Empty when netlink
+	// events are disabled or on Windows.
+	delMu          sync.Mutex
+	deletedIndexes map[int]struct{}
+	// hooks holds the watcher's OS-facing dependencies (netlink calls on linux),
+	// injectable per instance in tests. The type is defined per-OS. A zero value
+	// means production defaults (see osHooks on linux).
+	hooks hooks //nolint:unused // driven by osHooks on linux; windows has no netlink hooks
 }
 
 var e *EndpointWatcher
 
 // NewEndpointWatcher creates a new endpoint watcher.
-func Watcher() *EndpointWatcher {
+func Watcher(enableNetlinkEvents bool) *EndpointWatcher {
 	if e == nil {
 		e = &EndpointWatcher{
 			isRunning: false,
@@ -32,6 +50,7 @@ func Watcher() *EndpointWatcher {
 			current:   make(cache),
 		}
 	}
+	e.enableNetlinkEvents = enableNetlinkEvents
 
 	return e
 }
@@ -41,6 +60,12 @@ func (e *EndpointWatcher) Init(ctx context.Context) error {
 		e.l.Info("endpoint watcher is already running")
 		return nil
 	}
+	ctx, e.cancel = context.WithCancel(ctx)
+	// Register the snapshot source before subscribers join so a subscriber that
+	// joins after the watcher (e.g. packetparser) replays the current veth set
+	// immediately instead of waiting for the next refresh.
+	e.p.RegisterSource(common.PubSubEndpoints, e.snapshot)
+	e.subscribe(ctx)
 	e.isRunning = true
 	return nil
 }
@@ -50,31 +75,100 @@ func (e *EndpointWatcher) Stop(ctx context.Context) error {
 		e.l.Info("endpoint watcher is not running")
 		return nil
 	}
+	if e.cancel != nil {
+		e.cancel()
+		e.cancel = nil
+	}
 	e.isRunning = false
 	return nil
 }
 
+// recordDeletedIndex notes an interface index netlink reported removed. Called
+// from the netlink reader goroutine; drained by Refresh.
+func (e *EndpointWatcher) recordDeletedIndex(index int) {
+	e.delMu.Lock()
+	if e.deletedIndexes == nil {
+		e.deletedIndexes = make(map[int]struct{})
+	}
+	e.deletedIndexes[index] = struct{}{}
+	e.delMu.Unlock()
+}
+
+// drainDeletedIndexes returns and clears the indexes netlink reported removed
+// since the last call.
+func (e *EndpointWatcher) drainDeletedIndexes() map[int]struct{} {
+	e.delMu.Lock()
+	d := e.deletedIndexes
+	e.deletedIndexes = nil
+	e.delMu.Unlock()
+	return d
+}
+
 func (e *EndpointWatcher) Refresh(ctx context.Context) error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	// Drain netlink-reported deletes BEFORE listing. A delete that lands after
+	// the list would pair with the stale pre-delete sample and misread as a
+	// reuse (index present in both old and new), publishing a spurious
+	// delete+create for an interface that is simply gone. Drained-first, a
+	// record inserted after this point stays queued for the next refresh —
+	// which the same delete event also triggers — so nothing is lost.
+	drained := e.drainDeletedIndexes()
+
 	// initNewCache is OS specific.
 	// Based on GOOS, will be implemented by either endpoint_linux, or
 	// endpoint_windows.
 	err := e.initNewCache()
 	if err != nil {
+		// Re-queue the drained records so a failed list doesn't lose them; a
+		// genuine reuse they describe would otherwise become undetectable.
+		for idx := range drained {
+			e.recordDeletedIndex(idx)
+		}
 		return err
 	}
 
-	// Compare the new veths with the old ones.
+	// Handle interface-index reuse before diffing. If netlink reported index N
+	// deleted and the re-list now shows a *different* interface at N (a new veth
+	// reused the freed index before we sampled), a plain diff sees N in both the
+	// old and new cache and emits nothing — leaving the old occupant attached and
+	// the new one unattached. Publish a delete for the old occupant now (so
+	// consumers detach) and drop it from current, so diffCache/the re-assert below
+	// treat the new occupant as freshly created and (re)attach it. Ordering holds:
+	// this delete is published before the create re-assert, and delivery is FIFO
+	// per subscriber. Pure deletes (N gone, not reused) are left to diffCache.
+	for idx := range drained {
+		k := key{index: idx}
+		old, inCurrent := e.current[k]
+		if _, inNew := e.new[k]; !inCurrent || !inNew {
+			continue
+		}
+		e.l.Info("interface index reused; detaching old interface before re-attaching",
+			zap.String("old", describeEndpoint(old)), zap.Int("index", idx))
+		e.p.Publish(common.PubSubEndpoints, NewEndpointEvent(EndpointDeleted, old))
+		delete(e.current, k)
+	}
+
 	created, deleted := e.diffCache()
 
-	// Publish the new veths.
+	// Log interfaces appearing/disappearing (the diff only, not the full
+	// re-assert below) at info, mirroring the apiserver watcher's IP logging.
 	for _, v := range created {
-		e.l.Debug("Endpoint created", zap.Any("veth", v))
+		e.l.Info("New endpoint interface", zap.String("endpoint", describeEndpoint(v)))
+	}
+	for _, v := range deleted {
+		e.l.Info("Deleted endpoint interface", zap.String("endpoint", describeEndpoint(v)))
+	}
+
+	// Re-assert every current veth on each refresh (level-triggered): consumers
+	// attach idempotently, so a create event dropped before a subscriber was
+	// ready self-heals on the next refresh.
+	for _, v := range e.new {
 		e.p.Publish(common.PubSubEndpoints, NewEndpointEvent(EndpointCreated, v))
 	}
 
 	// Publish the deleted veths.
 	for _, v := range deleted {
-		e.l.Debug("Endpoint deleted", zap.Any("veth", v))
 		e.p.Publish(common.PubSubEndpoints, NewEndpointEvent(EndpointDeleted, v))
 	}
 
@@ -83,6 +177,24 @@ func (e *EndpointWatcher) Refresh(ctx context.Context) error {
 	e.new = nil
 
 	return nil
+}
+
+// snapshot returns the current veth set as EndpointCreated events. Registered
+// as the pubsub source so a subscriber that joins after startup (e.g.
+// packetparser) receives the current set immediately instead of waiting for
+// the next refresh. It serves e.current — the same state deletes are diffed
+// against — under the same lock Refresh commits it: a subscriber can never
+// receive a create whose delete the diff would not later publish. (Listing the
+// kernel here instead could hand a subscriber a veth that dies before the next
+// Refresh commits it to current, orphaning the create forever.)
+func (e *EndpointWatcher) snapshot() []interface{} {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	events := make([]interface{}, 0, len(e.current))
+	for _, v := range e.current {
+		events = append(events, NewEndpointEvent(EndpointCreated, v))
+	}
+	return events
 }
 
 // Function to differentiate between two caches.

--- a/pkg/watchers/endpoint/endpoint_churn_ebpf_test.go
+++ b/pkg/watchers/endpoint/endpoint_churn_ebpf_test.go
@@ -1,0 +1,154 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+//go:build ebpf && linux
+
+// Real-kernel test for the pod-restart attach path. Creates and deletes veths
+// and verifies the netlink fast path emits EndpointCreated/EndpointDeleted with
+// low (sub-poll-interval) latency. Requires NET_ADMIN; run via `make test-ebpf`
+// (sudo) or in a privileged linux container:
+//
+//	docker run --privileged -v "$PWD":/src -w /src golang:1.26 \
+//	  go test -tags=ebpf -run VethChurn ./pkg/watchers/endpoint/
+package endpoint
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/microsoft/retina/pkg/common"
+	"github.com/microsoft/retina/pkg/log"
+	"github.com/microsoft/retina/pkg/pubsub"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/vishvananda/netlink"
+)
+
+const (
+	churnRounds = 20
+	namePool    = 5
+	vethPrefix  = "rtnchurn"
+	peerPrefix  = "rtnpeer" // deliberately not matching vethPrefix so peers are ignored
+)
+
+// cleanupChurnVeths removes any leftover test veths (deleting one end removes the pair).
+func cleanupChurnVeths(t *testing.T) {
+	t.Helper()
+	links, err := netlink.LinkList()
+	if err != nil {
+		return
+	}
+	for _, l := range links {
+		n := l.Attrs().Name
+		if strings.HasPrefix(n, vethPrefix) || strings.HasPrefix(n, peerPrefix) {
+			_ = netlink.LinkDel(l)
+		}
+	}
+}
+
+// TestVethChurnLatency simulates pod restarts (delete/recreate of the same veth
+// identity) and asserts every create yields an EndpointCreated quickly and every
+// delete yields an EndpointDeleted.
+func TestVethChurnLatency(t *testing.T) {
+	log.SetupZapLogger(log.GetDefaultLogOpts())
+	cleanupChurnVeths(t)
+	t.Cleanup(func() { cleanupChurnVeths(t) })
+
+	ps := pubsub.New()
+
+	var mu sync.Mutex
+	createdAt := map[string]time.Time{}
+	deletedAt := map[string]time.Time{}
+	cb := pubsub.CallBackFunc(func(msg interface{}) {
+		ev, ok := msg.(*EndpointEvent)
+		if !ok {
+			return
+		}
+		attrs, ok := ev.Obj.(netlink.LinkAttrs)
+		if !ok || !strings.HasPrefix(attrs.Name, vethPrefix) {
+			return
+		}
+		mu.Lock()
+		defer mu.Unlock()
+		switch ev.Type {
+		case EndpointCreated:
+			if _, seen := createdAt[attrs.Name]; !seen {
+				createdAt[attrs.Name] = time.Now()
+			}
+		case EndpointDeleted:
+			if _, seen := deletedAt[attrs.Name]; !seen {
+				deletedAt[attrs.Name] = time.Now()
+			}
+		}
+	})
+	id := ps.Subscribe(common.PubSubEndpoints, &cb)
+	defer ps.Unsubscribe(common.PubSubEndpoints, id) //nolint:errcheck
+
+	v := &EndpointWatcher{
+		enableNetlinkEvents: true,
+		l:                   log.Logger().Named("churn-watcher"),
+		p:                   ps,
+		current:             make(cache),
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	v.subscribe(ctx)
+
+	var latencies []time.Duration
+	for i := 0; i < churnRounds; i++ {
+		// Reuse a small name pool so each round is a delete+recreate of the same
+		// pod-like identity — the exact path a pod restart exercises.
+		name := fmt.Sprintf("%s%d", vethPrefix, i%namePool)
+		peer := fmt.Sprintf("%s%d", peerPrefix, i%namePool)
+
+		la := netlink.NewLinkAttrs()
+		la.Name = name
+		veth := &netlink.Veth{LinkAttrs: la, PeerName: peer}
+
+		start := time.Now()
+		require.NoError(t, netlink.LinkAdd(veth), "LinkAdd %s (round %d)", name, i)
+
+		require.Eventually(t, func() bool {
+			mu.Lock()
+			defer mu.Unlock()
+			_, ok := createdAt[name]
+			return ok
+		}, 5*time.Second, 2*time.Millisecond, "EndpointCreated for %s (round %d)", name, i)
+
+		mu.Lock()
+		latencies = append(latencies, createdAt[name].Sub(start))
+		mu.Unlock()
+
+		require.NoError(t, netlink.LinkDel(veth), "LinkDel %s (round %d)", name, i)
+
+		require.Eventually(t, func() bool {
+			mu.Lock()
+			defer mu.Unlock()
+			_, ok := deletedAt[name]
+			return ok
+		}, 5*time.Second, 2*time.Millisecond, "EndpointDeleted for %s (round %d)", name, i)
+
+		// Reset so the next reuse of this name is observed afresh.
+		mu.Lock()
+		delete(createdAt, name)
+		delete(deletedAt, name)
+		mu.Unlock()
+	}
+
+	var maxLat, total time.Duration
+	for _, l := range latencies {
+		total += l
+		if l > maxLat {
+			maxLat = l
+		}
+	}
+	avg := total / time.Duration(len(latencies))
+	t.Logf("veth create->EndpointCreated latency: avg=%v max=%v over %d rounds", avg, maxLat, len(latencies))
+
+	// The whole point: attach latency is event-driven, not bound to the poll interval.
+	assert.Less(t, maxLat, 2*time.Second, "attach event latency should be far below any refresh interval")
+}

--- a/pkg/watchers/endpoint/endpoint_linux.go
+++ b/pkg/watchers/endpoint/endpoint_linux.go
@@ -4,13 +4,181 @@
 package endpoint
 
 import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
 	"github.com/vishvananda/netlink"
+	"go.uber.org/zap"
+	"golang.org/x/sys/unix"
 )
 
-var showLink = netlink.LinkList
+// listVethsMaxAttempts bounds how many times listVeths retries a dump that the
+// kernel reported interrupted (NLM_F_DUMP_INTR). A dump races a concurrent link
+// change; retrying gets a consistent snapshot instead of reconciling against a
+// partial one (which would look like spurious deletes).
+const listVethsMaxAttempts = 5
+
+const (
+	linkUpdateChanSize = 64
+	// defaultResubscribeBackoff is the delay before re-establishing a dead
+	// netlink subscription.
+	defaultResubscribeBackoff = 2 * time.Second
+)
+
+// hooks are the watcher's OS-facing dependencies, injectable per instance in
+// tests. Instance fields rather than package vars: watcher goroutines outlive a
+// test body, so swapping-and-restoring globals races their reads.
+type hooks struct {
+	listLinks          func() ([]netlink.Link, error)
+	linkSubscribe      func(chan<- netlink.LinkUpdate, <-chan struct{}, netlink.LinkSubscribeOptions) error
+	resubscribeBackoff time.Duration
+}
+
+// osHooks returns the instance hooks with production defaults filled in for any
+// zero fields, so a watcher constructed without hooks behaves like production.
+func (e *EndpointWatcher) osHooks() hooks {
+	h := e.hooks
+	if h.listLinks == nil {
+		h.listLinks = netlink.LinkList
+	}
+	if h.linkSubscribe == nil {
+		h.linkSubscribe = netlink.LinkSubscribeWithOptions
+	}
+	if h.resubscribeBackoff == 0 {
+		h.resubscribeBackoff = defaultResubscribeBackoff
+	}
+	return h
+}
+
+// subscribe triggers an immediate Refresh whenever a veth appears or disappears,
+// removing the up-to-refresh-interval attach delay. Periodic Refresh remains the backstop.
+func (e *EndpointWatcher) subscribe(ctx context.Context) {
+	if !e.enableNetlinkEvents {
+		return
+	}
+	trigger := make(chan struct{}, 1)
+	go e.runNetlink(ctx, trigger)   // keeps a subscription alive, records events
+	go e.runRefresher(ctx, trigger) // reconciles when triggered
+}
+
+// runNetlink keeps a netlink link subscription alive. The netlink library ends its
+// receive goroutine on any receive error, which closes the updates channel. We
+// detect that and resubscribe after a backoff,
+// and reconcile on every (re)connect so state cannot drift while the fast path was
+// down. Periodic Refresh remains the ultimate backstop, so a transient outage only
+// adds latency, never a permanent loss of the fast path.
+//
+// An RTM_DELLINK dropped while the subscription is down is never recorded, so an
+// index reuse spanning the outage is invisible to Refresh's reuse detection. That
+// is compensated downstream: the level-triggered re-assert redelivers every
+// current interface each refresh, and packetparser verifies recorded attachments
+// are still live in the kernel before skipping (see createQdiscAndAttach) — TCX
+// via the link's ifindex, legacy TC via a targeted per-ifindex filter presence
+// query — so a stale attachment self-heals within one refresh (for legacy TC's
+// accepted false-alive gaps, see tcAttachmentAlive).
+func (e *EndpointWatcher) runNetlink(ctx context.Context, trigger chan<- struct{}) {
+	h := e.osHooks()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+
+		// Per-subscription done channel: closing it lets the netlink library close
+		// its socket, so resubscribing doesn't leak the previous one.
+		subDone := make(chan struct{})
+		updates := make(chan netlink.LinkUpdate, linkUpdateChanSize)
+		err := h.linkSubscribe(updates, subDone, netlink.LinkSubscribeOptions{
+			ListExisting: true,
+			ErrorCallback: func(err error) {
+				// The initial ListExisting dump can race a link change; our reconcile
+				// re-lists (with its own retry), so this is benign.
+				if errors.Is(err, netlink.ErrDumpInterrupted) {
+					e.l.Debug("netlink initial dump interrupted; reconcile will re-list", zap.Error(err))
+					return
+				}
+				e.l.Warn("netlink link subscription error", zap.Error(err))
+			},
+		})
+		if err != nil {
+			e.l.Error("netlink subscribe failed; retrying", zap.Error(err))
+		} else {
+			e.l.Info("netlink-driven endpoint refresh enabled")
+			// ListExisting replays every current link as an event, so (re)connecting
+			// drives a reconcile on its own — catching anything that changed while the
+			// subscription was down without an explicit kick here.
+			e.readLinkUpdates(ctx, updates, trigger)
+		}
+		close(subDone) // release this subscription's socket
+
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(h.resubscribeBackoff):
+		}
+	}
+}
+
+// readLinkUpdates drains a subscription until it closes (netlink ended it) or the
+// watcher stops, returning so runNetlink can resubscribe.
+func (e *EndpointWatcher) readLinkUpdates(ctx context.Context, updates <-chan netlink.LinkUpdate, trigger chan<- struct{}) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case u, ok := <-updates:
+			if !ok {
+				e.l.Warn("netlink subscription closed; resubscribing")
+				return
+			}
+			if u.Link == nil || u.Type() != "veth" {
+				continue
+			}
+			// RTM_DELLINK carries the veth type, so record the removed index here.
+			// Refresh uses it to detect a delete+recreate that reused the index
+			// within a single reconcile (see Refresh).
+			if u.Header.Type == unix.RTM_DELLINK {
+				e.recordDeletedIndex(u.Attrs().Index)
+			}
+			e.signal(trigger)
+		}
+	}
+}
+
+func (e *EndpointWatcher) runRefresher(ctx context.Context, trigger <-chan struct{}) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-trigger:
+			if err := e.Refresh(ctx); err != nil {
+				e.l.Error("netlink-driven refresh failed", zap.Error(err))
+			}
+		}
+	}
+}
+
+// signal requests a reconcile without blocking; a pending request coalesces.
+func (e *EndpointWatcher) signal(trigger chan<- struct{}) {
+	select {
+	case trigger <- struct{}{}:
+	default:
+	}
+}
+
+// describeEndpoint renders a veth for logging as "name (index N)".
+func describeEndpoint(v interface{}) string {
+	if a, ok := v.(netlink.LinkAttrs); ok {
+		return fmt.Sprintf("%s (index %d)", a.Name, a.Index)
+	}
+	return "unknown"
+}
 
 func (e *EndpointWatcher) initNewCache() error {
-	veths, err := listVeths()
+	veths, err := e.listVeths()
 	if err != nil {
 		return err
 	}
@@ -19,9 +187,7 @@ func (e *EndpointWatcher) initNewCache() error {
 	e.new = make(cache)
 	for _, veth := range veths {
 		k := key{
-			name:         veth.Attrs().Name,
-			hardwareAddr: veth.Attrs().HardwareAddr.String(),
-			netNsID:      veth.Attrs().NetNsID,
+			index: veth.Attrs().Index,
 		}
 
 		e.new[k] = *veth.Attrs()
@@ -30,12 +196,19 @@ func (e *EndpointWatcher) initNewCache() error {
 	return nil
 }
 
-// Helper functions.
-
-// Get all the veth interfaces.
-// Similar to ip link show type veth
-func listVeths() ([]netlink.Link, error) {
-	links, err := showLink()
+// listVeths returns all veth interfaces, like `ip link show type veth`.
+func (e *EndpointWatcher) listVeths() ([]netlink.Link, error) {
+	listLinks := e.osHooks().listLinks
+	var links []netlink.Link
+	var err error
+	for range listVethsMaxAttempts {
+		links, err = listLinks()
+		// On a clean dump (or a non-retryable error) stop; on an interrupted dump
+		// the results may be incomplete, so discard and retry for a consistent one.
+		if !errors.Is(err, netlink.ErrDumpInterrupted) {
+			break
+		}
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/watchers/endpoint/endpoint_linux_test.go
+++ b/pkg/watchers/endpoint/endpoint_linux_test.go
@@ -7,33 +7,41 @@ package endpoint
 import (
 	"context"
 	"errors"
-	"net"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
+	"github.com/microsoft/retina/pkg/common"
 	"github.com/microsoft/retina/pkg/log"
 	"github.com/microsoft/retina/pkg/pubsub"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
 )
 
-func TestGetWatcher(t *testing.T) {
-	log.SetupZapLogger(log.GetDefaultLogOpts())
+var errTest = errors.New("test error")
 
-	v := Watcher()
+func TestGetWatcher(t *testing.T) {
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
+
+	v := Watcher(false)
 	assert.NotNil(t, v)
 
-	v_again := Watcher()
-	assert.Equal(t, v, v_again, "Expected the same veth watcher instance")
+	vAgain := Watcher(false)
+	assert.Equal(t, v, vAgain, "Expected the same veth watcher instance")
 }
 
 func TestEndpointWatcherStart(t *testing.T) {
-	log.SetupZapLogger(log.GetDefaultLogOpts())
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
 	c := context.Background()
 
 	// When veth is already running.
 	v := &EndpointWatcher{
 		isRunning: true,
 		l:         log.Logger().Named("veth-watcher"),
+		p:         pubsub.New(),
 	}
 	err := v.Init(c)
 	assert.NoError(t, err, "Expected no error when starting a running veth watcher")
@@ -60,13 +68,14 @@ func TestEndpointWatcherStart(t *testing.T) {
 }
 
 func TestEndpointWatcherStop(t *testing.T) {
-	log.SetupZapLogger(log.GetDefaultLogOpts())
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
 	c := context.Background()
 
 	// When veth is already stopped.
 	v := &EndpointWatcher{
 		isRunning: false,
 		l:         log.Logger().Named("veth-watcher"),
+		p:         pubsub.New(),
 	}
 	err := v.Stop(c)
 	assert.NoError(t, err, "Expected no error when stopping a stopped veth watcher")
@@ -83,7 +92,7 @@ func TestEndpointWatcherStop(t *testing.T) {
 }
 
 func TestRun(t *testing.T) {
-	showLink = func() ([]netlink.Link, error) {
+	v := &EndpointWatcher{hooks: hooks{listLinks: func() ([]netlink.Link, error) {
 		return []netlink.Link{
 			&netlink.Veth{
 				LinkAttrs: netlink.LinkAttrs{
@@ -96,9 +105,9 @@ func TestRun(t *testing.T) {
 				},
 			},
 		}, nil
-	}
+	}}}
 
-	links, err := listVeths()
+	links, err := v.listVeths()
 	assert.NoError(t, err, "Expected no error when listing veths")
 	assert.Equal(t, 1, len(links), "Expected to find 1 veth")
 	assert.Equal(t, "veth0", links[0].Attrs().Name, "Expected to find veth0")
@@ -107,18 +116,14 @@ func TestRun(t *testing.T) {
 func TestDiffCache(t *testing.T) {
 	old := cache{
 		key{
-			name:         "veth0",
-			hardwareAddr: "00:00:00:00:00:00",
-			netNsID:      0,
+			index: 0,
 		}: netlink.LinkAttrs{
 			Name: "veth0",
 		},
 	}
 	new := cache{
 		key{
-			name:         "veth1",
-			hardwareAddr: "00:00:00:00:00:FF",
-			netNsID:      1,
+			index: 1,
 		}: netlink.LinkAttrs{
 			Name: "veth1",
 		},
@@ -132,29 +137,21 @@ func TestDiffCache(t *testing.T) {
 }
 
 func TestRefreshAndCallback(t *testing.T) {
-	log.SetupZapLogger(log.GetDefaultLogOpts())
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
 	c := context.Background()
 
-	showLink = func() ([]netlink.Link, error) {
+	listLinks := func() ([]netlink.Link, error) {
 		return []netlink.Link{
 			&netlink.Veth{
 				LinkAttrs: netlink.LinkAttrs{
-					Name: "veth0",
-					HardwareAddr: func() net.HardwareAddr {
-						mac, _ := net.ParseMAC("00:00:00:00:00:00")
-						return mac
-					}(),
-					NetNsID: 0,
+					Name:  "veth0",
+					Index: 10,
 				},
 			},
 			&netlink.Veth{
 				LinkAttrs: netlink.LinkAttrs{
-					Name: "veth1",
-					HardwareAddr: func() net.HardwareAddr {
-						mac, _ := net.ParseMAC("00:00:00:00:00:01")
-						return mac
-					}(),
-					NetNsID: 1,
+					Name:  "veth1",
+					Index: 11,
 				},
 			},
 		}, nil
@@ -162,9 +159,7 @@ func TestRefreshAndCallback(t *testing.T) {
 
 	cache := make(cache)
 	cache[key{
-		name:         "veth2",
-		hardwareAddr: "00:00:00:00:00:02",
-		netNsID:      2,
+		index: 12,
 	}] = &netlink.Veth{
 		LinkAttrs: netlink.LinkAttrs{
 			Name: "veth2",
@@ -176,6 +171,7 @@ func TestRefreshAndCallback(t *testing.T) {
 		current:   cache,
 		l:         log.Logger().Named("veth-watcher"),
 		p:         pubsub.New(),
+		hooks:     hooks{listLinks: listLinks},
 	}
 
 	// When cache is empty.
@@ -186,43 +182,456 @@ func TestRefreshAndCallback(t *testing.T) {
 	assert.NoError(t, err, "Expected no error when refreshing veth cache")
 	assert.Equal(t, 2, len(v.current), "Expected to find 2 veths")
 	assert.Equal(t, "veth0", v.current[key{
-		name:         "veth0",
-		hardwareAddr: "00:00:00:00:00:00",
-		netNsID:      0,
+		index: 10,
 	}].(netlink.LinkAttrs).Name, "Expected to find veth0")
 	assert.Equal(t, "veth1", v.current[key{
-		name:         "veth1",
-		hardwareAddr: "00:00:00:00:00:01",
-		netNsID:      1,
+		index: 11,
 	}].(netlink.LinkAttrs).Name, "Expected to find veth1")
 }
 
 func TestRefreshError(t *testing.T) {
-	log.SetupZapLogger(log.GetDefaultLogOpts())
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
 	c := context.Background()
-
-	showLink = func() ([]netlink.Link, error) {
-		return nil, errors.New("error")
-	}
 
 	v := &EndpointWatcher{
 		isRunning: true,
 		current:   make(cache),
 		l:         log.Logger().Named("veth-watcher"),
 		p:         pubsub.New(),
+		hooks: hooks{listLinks: func() ([]netlink.Link, error) {
+			return nil, errTest
+		}},
 	}
 
 	err := v.Refresh(c)
 	assert.Error(t, err, "Expected an error when refreshing veth cache")
 }
 
-func TestListVethsError(t *testing.T) {
-	log.SetupZapLogger(log.GetDefaultLogOpts())
+func TestRefreshReassertsAllCurrent(t *testing.T) {
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
 
-	showLink = func() ([]netlink.Link, error) {
-		return nil, errors.New("error")
+	ps := pubsub.New()
+	var created atomic.Int32
+	fn := pubsub.CallBackFunc(func(msg interface{}) {
+		if ev, ok := msg.(*EndpointEvent); ok && ev.Type == EndpointCreated {
+			created.Add(1)
+		}
+	})
+	id := ps.Subscribe(common.PubSubEndpoints, &fn)
+	defer ps.Unsubscribe(common.PubSubEndpoints, id) //nolint:errcheck // best-effort cleanup in test
+
+	v := &EndpointWatcher{
+		current: make(cache),
+		l:       log.Logger().Named("veth-watcher"),
+		p:       ps,
+		hooks: hooks{listLinks: func() ([]netlink.Link, error) {
+			return []netlink.Link{
+				&netlink.Veth{LinkAttrs: netlink.LinkAttrs{Name: "veth0"}},
+			}, nil
+		}},
 	}
 
-	_, err := listVeths()
+	c := context.Background()
+	assert.NoError(t, v.Refresh(c))
+	assert.NoError(t, v.Refresh(c))
+
+	// Level-triggered: the veth is re-published on every refresh. Publish runs
+	// callbacks asynchronously, so poll. Use >= 2 because a snapshot source may
+	// also be registered on the shared pubsub singleton and add replays.
+	assert.Eventually(t, func() bool { return created.Load() >= 2 }, time.Second, 10*time.Millisecond,
+		"expected the veth to be re-asserted on each refresh")
+}
+
+func TestNetlinkTriggersRefresh(t *testing.T) {
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
+
+	capturedCh := make(chan chan<- netlink.LinkUpdate, 1)
+	v := &EndpointWatcher{
+		enableNetlinkEvents: true,
+		l:                   log.Logger().Named("veth-watcher"),
+		p:                   pubsub.New(),
+		current:             make(cache),
+		hooks: hooks{
+			listLinks: func() ([]netlink.Link, error) {
+				return []netlink.Link{
+					&netlink.Veth{LinkAttrs: netlink.LinkAttrs{Name: "veth-new"}},
+				}, nil
+			},
+			linkSubscribe: func(ch chan<- netlink.LinkUpdate, _ <-chan struct{}, _ netlink.LinkSubscribeOptions) error {
+				capturedCh <- ch
+				return nil
+			},
+		},
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	v.subscribe(ctx)
+
+	ch := <-capturedCh
+	ch <- netlink.LinkUpdate{Link: &netlink.Veth{LinkAttrs: netlink.LinkAttrs{Name: "veth-new"}}}
+
+	assert.Eventually(t, func() bool {
+		v.mu.Lock()
+		defer v.mu.Unlock()
+		return len(v.current) == 1
+	}, time.Second, 10*time.Millisecond, "expected netlink event to trigger a refresh")
+}
+
+// endpointEvent is a captured (type, name) pair for a given interface index.
+type endpointEvent struct {
+	typ  EventType
+	name string
+}
+
+// captureEndpointEvents subscribes and records events for a single interface index.
+func captureEndpointEvents(t *testing.T, ps pubsub.PubSubInterface, index int) (*sync.Mutex, *[]endpointEvent) {
+	t.Helper()
+	var mu sync.Mutex
+	events := &[]endpointEvent{}
+	fn := pubsub.CallBackFunc(func(msg interface{}) {
+		e, ok := msg.(*EndpointEvent)
+		if !ok {
+			return
+		}
+		attrs, ok := e.Obj.(netlink.LinkAttrs)
+		if !ok || attrs.Index != index {
+			return
+		}
+		mu.Lock()
+		*events = append(*events, endpointEvent{e.Type, attrs.Name})
+		mu.Unlock()
+	})
+	id := ps.Subscribe(common.PubSubEndpoints, &fn)
+	t.Cleanup(func() { ps.Unsubscribe(common.PubSubEndpoints, id) }) //nolint:errcheck // best-effort cleanup in test
+	return &mu, events
+}
+
+// A veth can be deleted and a new veth can reuse its interface index before the
+// watcher re-lists. diffCache alone sees the index in both snapshots and emits
+// nothing, so the old occupant stays attached and the new one never attaches.
+// The netlink delete record must force a detach of the old occupant followed by
+// an attach of the new one. This drives it end-to-end through the netlink reader.
+func TestNetlinkDeleteTriggersReattachOnIndexReuse(t *testing.T) {
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
+
+	const idx = 4242
+	capturedCh := make(chan chan<- netlink.LinkUpdate, 1)
+	ps := pubsub.New()
+	mu, events := captureEndpointEvents(t, ps, idx)
+
+	v := &EndpointWatcher{
+		enableNetlinkEvents: true,
+		l:                   log.Logger().Named("veth-watcher"),
+		p:                   ps,
+		current:             cache{key{index: idx}: netlink.LinkAttrs{Name: "vethA", Index: idx}},
+		hooks: hooks{
+			listLinks: func() ([]netlink.Link, error) {
+				return []netlink.Link{
+					&netlink.Veth{LinkAttrs: netlink.LinkAttrs{Name: "vethB", Index: idx}},
+				}, nil
+			},
+			linkSubscribe: func(ch chan<- netlink.LinkUpdate, _ <-chan struct{}, _ netlink.LinkSubscribeOptions) error {
+				capturedCh <- ch
+				return nil
+			},
+		},
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	v.subscribe(ctx)
+
+	ch := <-capturedCh
+	ch <- netlink.LinkUpdate{
+		Header: unix.NlMsghdr{Type: unix.RTM_DELLINK},
+		Link:   &netlink.Veth{LinkAttrs: netlink.LinkAttrs{Name: "vethA", Index: idx}},
+	}
+
+	assert.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		del := -1
+		for i, e := range *events {
+			if e.typ == EndpointDeleted && e.name == "vethA" {
+				del = i
+				break
+			}
+		}
+		if del < 0 {
+			return false
+		}
+		for _, e := range (*events)[del+1:] {
+			if e.typ == EndpointCreated && e.name == "vethB" {
+				return true
+			}
+		}
+		return false
+	}, 2*time.Second, 10*time.Millisecond,
+		"expected netlink delete of a reused index to detach vethA then attach vethB")
+}
+
+// A drained delete record must survive a failed re-list: Refresh re-queues it,
+// so a reuse that spans the transient failure is still detected on the next
+// pass (delete of the old occupant before the create of the new one).
+func TestRefreshRequeuesDrainedDeletesOnListFailure(t *testing.T) {
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
+
+	const idx = 6001
+	ps := pubsub.New()
+	mu, events := captureEndpointEvents(t, ps, idx)
+
+	calls := 0
+	v := &EndpointWatcher{
+		l:       log.Logger().Named("veth-watcher"),
+		p:       ps,
+		current: cache{key{index: idx}: netlink.LinkAttrs{Name: "vethA", Index: idx}},
+		hooks: hooks{listLinks: func() ([]netlink.Link, error) {
+			calls++
+			if calls == 1 {
+				return nil, errTest
+			}
+			return []netlink.Link{
+				&netlink.Veth{LinkAttrs: netlink.LinkAttrs{Name: "vethB", Index: idx}},
+			}, nil
+		}},
+	}
+	v.recordDeletedIndex(idx)
+
+	require.Error(t, v.Refresh(context.Background()), "first refresh surfaces the list failure")
+	require.NoError(t, v.Refresh(context.Background()))
+
+	assert.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		del := -1
+		for i, e := range *events {
+			if e.typ == EndpointDeleted && e.name == "vethA" {
+				del = i
+				break
+			}
+		}
+		if del < 0 {
+			return false
+		}
+		for _, e := range (*events)[del+1:] {
+			if e.typ == EndpointCreated && e.name == "vethB" {
+				return true
+			}
+		}
+		return false
+	}, 2*time.Second, 10*time.Millisecond,
+		"a reuse spanning a failed list must still detach vethA then attach vethB")
+}
+
+// A netlink-reported delete for an index that was NOT reused is handled by
+// diffCache normally; the reuse path must skip it so the delete isn't published
+// twice.
+func TestRefreshPlainDeleteEmitsSingleDelete(t *testing.T) {
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
+
+	const idx = 5555
+	ps := pubsub.New()
+	var deletes atomic.Int32
+	fn := pubsub.CallBackFunc(func(msg interface{}) {
+		e, ok := msg.(*EndpointEvent)
+		if !ok {
+			return
+		}
+		if attrs, ok := e.Obj.(netlink.LinkAttrs); ok && attrs.Index == idx && e.Type == EndpointDeleted {
+			deletes.Add(1)
+		}
+	})
+	id := ps.Subscribe(common.PubSubEndpoints, &fn)
+	defer ps.Unsubscribe(common.PubSubEndpoints, id) //nolint:errcheck // best-effort cleanup in test
+
+	v := &EndpointWatcher{
+		current: cache{key{index: idx}: netlink.LinkAttrs{Name: "vethGone", Index: idx}},
+		l:       log.Logger().Named("veth-watcher"),
+		p:       ps,
+		// index gone, not reused
+		hooks: hooks{listLinks: func() ([]netlink.Link, error) { return nil, nil }},
+	}
+	v.recordDeletedIndex(idx)
+	assert.NoError(t, v.Refresh(context.Background()))
+	assert.NoError(t, v.Refresh(context.Background()))
+
+	assert.Eventually(t, func() bool { return deletes.Load() >= 1 }, time.Second, 10*time.Millisecond,
+		"expected the deleted index to be published as deleted")
+	// Let any erroneous duplicate arrive before asserting it was published once.
+	time.Sleep(100 * time.Millisecond)
+	assert.Equal(t, int32(1), deletes.Load(), "delete must be published exactly once (no double-emit)")
+}
+
+// TestSnapshotReturnsCurrentVeths verifies the pubsub snapshot source serves the
+// committed current set as EndpointCreated events, so a subscriber joining after
+// startup converges to the same state deletes are diffed against.
+func TestSnapshotReturnsCurrentVeths(t *testing.T) {
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
+
+	v := &EndpointWatcher{
+		l: log.Logger().Named("veth-watcher"),
+		current: cache{
+			key{index: 7}: netlink.LinkAttrs{Name: "veth0", Index: 7},
+			key{index: 8}: netlink.LinkAttrs{Name: "veth1", Index: 8},
+		},
+	}
+
+	snap := v.snapshot()
+	assert.Len(t, snap, 2, "snapshot should include every current veth")
+	seen := map[int]bool{}
+	for _, item := range snap {
+		ev, ok := item.(*EndpointEvent)
+		assert.True(t, ok, "snapshot item should be an *EndpointEvent")
+		assert.Equal(t, EndpointCreated, ev.Type, "snapshot events should be creates")
+		attrs, ok := ev.Obj.(netlink.LinkAttrs)
+		assert.True(t, ok, "snapshot event payload should be netlink.LinkAttrs")
+		seen[attrs.Index] = true
+	}
+	assert.True(t, seen[7] && seen[8], "snapshot should carry both veth indexes")
+}
+
+// A snapshot must never hand a subscriber a veth the diff state doesn't know
+// about: a create served from a fresh kernel list, for a veth that dies before
+// the next Refresh commits it to current, would have no matching delete ever —
+// the subscriber holds an attachment forever. Serving from current makes this
+// impossible: the veth is either committed (its later delete will be diffed and
+// published) or absent from the snapshot.
+func TestSnapshotServesCommittedStateNotKernelList(t *testing.T) {
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
+
+	kernelHas := []netlink.Link{
+		&netlink.Veth{LinkAttrs: netlink.LinkAttrs{Name: "veth-uncommitted", Index: 9}},
+	}
+	v := &EndpointWatcher{
+		l:       log.Logger().Named("veth-watcher"),
+		current: make(cache), // nothing committed yet
+		hooks:   hooks{listLinks: func() ([]netlink.Link, error) { return kernelHas, nil }},
+	}
+
+	assert.Empty(t, v.snapshot(),
+		"snapshot must not surface veths the diff state has not committed")
+}
+
+// The netlink library ends its subscription (closing the updates channel) on any
+// receive error, including a socket-buffer overflow. The watcher must resubscribe
+// rather than silently lose the fast path for the rest of the process's life.
+func TestNetlinkResubscribesAfterClose(t *testing.T) {
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
+
+	var calls atomic.Int32
+	chs := make(chan chan<- netlink.LinkUpdate, 64)
+	v := &EndpointWatcher{
+		enableNetlinkEvents: true,
+		l:                   log.Logger().Named("veth-watcher"),
+		p:                   pubsub.New(),
+		current:             make(cache),
+		hooks: hooks{
+			resubscribeBackoff: 10 * time.Millisecond,
+			listLinks:          func() ([]netlink.Link, error) { return nil, nil },
+			linkSubscribe: func(ch chan<- netlink.LinkUpdate, _ <-chan struct{}, _ netlink.LinkSubscribeOptions) error {
+				calls.Add(1)
+				select {
+				case chs <- ch:
+				default:
+				}
+				return nil
+			},
+		},
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	v.subscribe(ctx)
+
+	// First subscription is established, then dies (channel closed).
+	ch1 := <-chs
+	close(ch1)
+
+	assert.Eventually(t, func() bool { return calls.Load() >= 2 }, 2*time.Second, 10*time.Millisecond,
+		"expected the watcher to resubscribe after the subscription closed")
+}
+
+// Stop must tear down the netlink goroutines Init started, without racing them:
+// Init derives an internal context and Stop cancels it (there is no separate
+// stop channel to race on). Observable via the per-subscription done channel,
+// which runNetlink closes on exit.
+func TestStopTearsDownNetlinkGoroutines(t *testing.T) {
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
+
+	subDones := make(chan (<-chan struct{}), 1)
+	v := &EndpointWatcher{
+		enableNetlinkEvents: true,
+		l:                   log.Logger().Named("veth-watcher"),
+		p:                   pubsub.New(),
+		current:             make(cache),
+		hooks: hooks{
+			resubscribeBackoff: 10 * time.Millisecond,
+			listLinks:          func() ([]netlink.Link, error) { return nil, nil },
+			linkSubscribe: func(_ chan<- netlink.LinkUpdate, done <-chan struct{}, _ netlink.LinkSubscribeOptions) error {
+				select {
+				case subDones <- done:
+				default:
+				}
+				return nil
+			},
+		},
+	}
+
+	require.NoError(t, v.Init(context.Background()))
+	done := <-subDones
+	require.NoError(t, v.Stop(context.Background()))
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("netlink goroutine did not exit after Stop")
+	}
+}
+
+// An interrupted dump (NLM_F_DUMP_INTR) may return incomplete results; listVeths
+// must retry for a consistent snapshot rather than surfacing partial data (which
+// would look like spurious interface deletes to the reconcile).
+func TestListVethsRetriesOnDumpInterrupted(t *testing.T) {
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
+
+	calls := 0
+	good := []netlink.Link{&netlink.Veth{LinkAttrs: netlink.LinkAttrs{Name: "veth0", Index: 3}}}
+	v := &EndpointWatcher{hooks: hooks{listLinks: func() ([]netlink.Link, error) {
+		calls++
+		if calls < 3 {
+			return nil, netlink.ErrDumpInterrupted
+		}
+		return good, nil
+	}}}
+
+	veths, err := v.listVeths()
+	require.NoError(t, err, "an interrupted dump should be retried, not surfaced")
+	assert.Equal(t, 3, calls, "listVeths should retry until it gets a consistent dump")
+	assert.Len(t, veths, 1, "should return the veths from the consistent dump")
+}
+
+// A persistently interrupted dump eventually gives up (bounded retries) and
+// surfaces the error, so Refresh skips the cycle rather than acting on bad data.
+func TestListVethsGivesUpAfterMaxDumpInterrupts(t *testing.T) {
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
+
+	calls := 0
+	v := &EndpointWatcher{hooks: hooks{listLinks: func() ([]netlink.Link, error) {
+		calls++
+		return nil, netlink.ErrDumpInterrupted
+	}}}
+
+	_, err := v.listVeths()
+	require.ErrorIs(t, err, netlink.ErrDumpInterrupted)
+	assert.Equal(t, listVethsMaxAttempts, calls, "should retry up to the bound then give up")
+}
+
+func TestListVethsError(t *testing.T) {
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
+
+	v := &EndpointWatcher{hooks: hooks{listLinks: func() ([]netlink.Link, error) {
+		return nil, errTest
+	}}}
+
+	_, err := v.listVeths()
 	assert.Error(t, err, "Expected an error when listing veths")
 }

--- a/pkg/watchers/endpoint/endpoint_windows.go
+++ b/pkg/watchers/endpoint/endpoint_windows.go
@@ -6,13 +6,16 @@
 package endpoint
 
 import (
-	"github.com/Microsoft/hcsshim/hcn"
+	"context"
 )
+
+// hooks has no OS-facing dependencies to inject on Windows.
+type hooks struct{} //nolint:unused // satisfies the shared EndpointWatcher.hooks field; no netlink on windows
+
+func (e *EndpointWatcher) subscribe(_ context.Context) {}
+
+func describeEndpoint(_ interface{}) string { return "" }
 
 func (e *EndpointWatcher) initNewCache() error {
 	return nil
-}
-
-func listVeths() ([]hcn.HostComputeEndpoint, error) {
-	return nil, nil
 }

--- a/pkg/watchers/endpoint/types.go
+++ b/pkg/watchers/endpoint/types.go
@@ -9,11 +9,11 @@ const (
 )
 
 type key struct {
-	name         string
-	hardwareAddr string
-	// Network namespace for linux.
-	// Compartment ID for windows.
-	netNsID int
+	// index is the interface index (linux) / compartment id (windows). It is the
+	// identifier the TCX/TC hook attaches with and is stable for the interface's
+	// lifetime, unlike name and NetNsID which change as a pod's veth is renamed
+	// and moved into its netns during init.
+	index int
 }
 
 type cache map[key]interface{}

--- a/test/managers/filtermanager/main.go
+++ b/test/managers/filtermanager/main.go
@@ -39,8 +39,8 @@ func main() {
 	ctx := context.Background()
 
 	// watcher manager
-	wm := watchermanager.NewWatcherManager(kcfg.DefaultFilterMapMaxEntries, 0)
-	wm.Watchers = []watchermanager.IWatcher{endpoint.Watcher(), apiserver.Watcher(kcfg.DefaultFilterMapMaxEntries)}
+	wm := watchermanager.NewWatcherManager(kcfg.DefaultFilterMapMaxEntries, false, 0)
+	wm.Watchers = []watchermanager.IWatcher{endpoint.Watcher(false), apiserver.Watcher(kcfg.DefaultFilterMapMaxEntries)}
 
 	err := wm.Start(ctx)
 	if err != nil {

--- a/test/plugin/packetparser/main_linux.go
+++ b/test/plugin/packetparser/main_linux.go
@@ -33,8 +33,8 @@ func main() {
 	ctxTimeout, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 
 	// watcher manager
-	wm := watchermanager.NewWatcherManager(kcfg.DefaultFilterMapMaxEntries, 0)
-	wm.Watchers = []watchermanager.IWatcher{endpoint.Watcher()}
+	wm := watchermanager.NewWatcherManager(kcfg.DefaultFilterMapMaxEntries, false, 0)
+	wm.Watchers = []watchermanager.IWatcher{endpoint.Watcher(false)}
 
 	err := wm.Start(ctxTimeout)
 	if err != nil {

--- a/test/watchers/apiserver/main.go
+++ b/test/watchers/apiserver/main.go
@@ -36,7 +36,7 @@ func main() {
 		}
 	}()
 	// watcher manager
-	wm := watchermanager.NewWatcherManager(kcfg.DefaultFilterMapMaxEntries, 0)
+	wm := watchermanager.NewWatcherManager(kcfg.DefaultFilterMapMaxEntries, false, 0)
 	wm.Watchers = []watchermanager.IWatcher{apiserver.Watcher(kcfg.DefaultFilterMapMaxEntries)}
 
 	// apiserver watcher.

--- a/test/watchers/veth/main.go
+++ b/test/watchers/veth/main.go
@@ -24,8 +24,8 @@ func main() {
 	ctx := context.Background()
 
 	// watcher manager
-	wm := watchermanager.NewWatcherManager(kcfg.DefaultFilterMapMaxEntries, 0)
-	wm.Watchers = []watchermanager.IWatcher{endpoint.Watcher()}
+	wm := watchermanager.NewWatcherManager(kcfg.DefaultFilterMapMaxEntries, false, 0)
+	wm.Watchers = []watchermanager.IWatcher{endpoint.Watcher(false)}
 
 	err := wm.Start(ctx)
 	if err != nil {


### PR DESCRIPTION
# Description

**Stack 5/5** (splits #9) — base `endpointWatcherEventDriven/4-apiserver-cache` (review after #18). This is the headline feature; the tip of this branch equals the original #9 tree (rebased on latest `microsoft/main`).

Makes the endpoint attach path **event-driven and self-healing**. On pod churn, eBPF programs attach within milliseconds of the veth appearing instead of waiting for the periodic refresh. Gated by `enableEndpointNetlinkEvents` (default `false`); the periodic refresh remains the backstop.

- **level-triggered reconcile**: re-asserts the full veth set each pass and serves a snapshot from committed state, so a missed event never means lost state — consumers converge on the next refresh (attach is idempotent + liveness-checked, see #16).
- **netlink fast path**: an optional `LinkSubscribe` goroutine triggers an immediate reconcile on veth add/remove; resubscribes with backoff on any subscription error; retries interrupted dumps.
- **index-reuse detection**: `RTM_DELLINK` records are drained before each list; a delete+recreate that reused an ifindex within one reconcile publishes a delete for the old occupant before re-asserting the new one (FIFO per subscriber), which a plain diff would miss.
- **lifecycle**: `Init` derives an internal context and `Stop` cancels it — one teardown signal for the netlink goroutines, propagating parent cancellation.
- config flag + helm/docs + `NewWatcherManager` threading.

**Modes** — Disabled (default): periodic reconcile + ordered delivery + snapshot + level-triggering, same timing as before with stronger convergence. Enabled: adds the ~ms netlink fast path on top.

## Related Issue

Splits #9 into a reviewable stack; this is part 5 of 5.

## Checklist

- [ ] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [x] I signed and signed-off the commits (`git commit -S -s ...`).
- [x] I have correctly attributed the author(s) of the code.
- [x] I have tested the changes locally.
- [x] I have followed the project's style guidelines.
- [x] I have updated the documentation, if necessary.
- [x] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

Unit: reuse detection (incl. across a failed re-list), plain-delete single-emit, resubscribe-after-close, ctx-cancel teardown, snapshot-from-committed-state, dump-interrupt retry. Real-kernel (`-tags=ebpf`): veth-churn attach latency. Config decode of the new keys. Race-clean.

## Additional Notes

Stack (review in order): 1 pubsub (#15) → 2 packetparser (#16) → 3 watchermanager (#17) → 4 apiserver/cache (#18) → **5 endpoint/netlink**.

Boundary note: the endpoint watcher's level-triggering and its netlink fast path live in the same file cluster, so this PR carries both rather than splitting them further.
